### PR TITLE
Add bot token env example and config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# === База данных ===
+DB_DSN="mysql:host=127.0.0.1;dbname=app;charset=utf8mb4"
+DB_USER="root"
+DB_PASS="secret"
+
+# === CORS ===
+CORS_ORIGINS="*"
+
+# === Telegram ===
+BOT_TOKEN="0000000000:AA..." # токен бота

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -28,6 +28,9 @@ JWT_ALG=HS256          # алгоритм (обычно HS256)
 # === CORS ===
 CORS_ORIGINS="*"       # список разрешённых origin через запятую
 
+# === Telegram ===
+BOT_TOKEN="0000000000:AA..." # токен Telegram-бота для проверки initData
+
 # === Rate limit ===
 RATE_LIMIT_BUCKET=ip   # тип лимита: ip или user
 RATE_LIMIT=60          # запросов в минуту
@@ -41,9 +44,14 @@ REDIS_DSN="tcp://127.0.0.1:6379"
 В `app/Config/config.php`:
 
 ```php
+'bot_token' => getenv('BOT_TOKEN'),
+
 'db' => [
     'dsn'  => getenv('DB_DSN'),
     'user' => getenv('DB_USER'),
     'pass' => getenv('DB_PASS'),
 ],
 ```
+
+`initData` от Telegram WebApp может передаваться в заголовке `Authorization: tma <данные>`,
+в заголовке `X-Telegram-Init-Data` или параметре `initData` (query/body).

--- a/app/Config/config.php
+++ b/app/Config/config.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 return [
     'app_env' => getenv('APP_ENV') ?: 'prod',
     'debug' => (bool)(getenv('APP_DEBUG') ?: false),
-    
+    'bot_token' => getenv('BOT_TOKEN'),
+
     'db' => [
         'dsn' => getenv('DB_DSN'),   // 'mysql:host=127.0.0.1;dbname=app;charset=utf8mb4'
         'user' => getenv('DB_USER'),

--- a/public/index.php
+++ b/public/index.php
@@ -80,7 +80,7 @@ $app->group('/api', function (\Slim\Routing\RouteCollectorProxy $g) use ($pdo, $
         $auth->post('/users', [\App\Controllers\Api\UsersController::class, 'create']);
     })->add(new \App\Middleware\RateLimitMiddleware($config['rate_limit']))
       ->add(new \App\Middleware\JwtMiddleware($config['jwt']));
-})->add(new \App\Middleware\TelegramInitDataMiddleware(getenv('BOT_TOKEN') ?: ''));
+})->add(new \App\Middleware\TelegramInitDataMiddleware($config['bot_token'] ?: ''));
 
 // === Запуск ===
 $app->run();


### PR DESCRIPTION
## Summary
- provide `.env.example` with database, CORS and Telegram bot token variables
- load BOT_TOKEN via config and use it in Telegram init data middleware
- document BOT_TOKEN and where Telegram initData can be supplied

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `composer tests` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86a18e3f4832dae3a9b9447ed02e4