### PR TITLE
docs: add Telegram mini app guidance and health checks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,10 +28,12 @@ vendor/
 1. **Единый вход** — `public/index.php`.
 2. **Контроллеры** — простые классы, работа напрямую с PDO.
 3. **PDO напрямую** — `$pdo->query()`, `$pdo->prepare()->execute()`.
-4. **Middleware** — только Jwt, Csrf, RateLimit, Error.
+4. **Middleware** — только Jwt, Csrf, RateLimit, TelegramInitData, Error.
 5. **Helpers\Response** — единый способ ответов (json/problem).
 6. **Dashboard и API** — разделены префиксами (`/dashboard`, `/api`).
 7. **Воркеры** — не изменяются.
+8. **Health-эндпойнт** — `/api/health` для мониторинга.
+9. **Telegram Mini App** — `TelegramInitDataMiddleware` проверяет `initData`.
 
 ## Чек-лист Code Review
 
@@ -40,4 +42,4 @@ vendor/
 - [ ] Без новых слоёв (Services — только если реально нужна переиспользуемая логика).
 - [ ] PDO используется напрямую.
 - [ ] Dashboard и API маршруты разделены.
-- [ ] Middleware не плодятся (только базовые).
+- [ ] Middleware не плодятся (только базовые: Error, Jwt, Csrf, RateLimit, TelegramInitData).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Формат: [Keep a Changelog](https://keepachangelog.com/ru/1.0.0/)
 
+## [Unreleased]
+- Заменены упоминания `/admin` на `/dashboard` в документации.
+- Добавлены инструкции по запуску health-эндпойнта, `TelegramInitDataMiddleware` и мини-приложению Telegram.
+- Описана переменная `BOT_TOKEN`, сценарии проверки `initData` и примеры запросов.
+
 ## [0.1.0] — 2025-08-22
 - Базовая структура каталогов.
 - Документация (ARCHITECTURE, README, CONTRIBUTING, CHANGELOG).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 - Включай `declare(strict_types=1)` во всех файлах.
 - Все ответы от API возвращаются через Helpers\Response.
 - PDO используется напрямую (никаких ORM/репозиториев).
-- Middleware не размножаем: только Error, Jwt, Csrf, RateLimit.
+- Middleware не размножаем: только Error, Jwt, Csrf, RateLimit, TelegramInitData.
 
 ## Добавление новой фичи
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -25,7 +25,7 @@
 ```bash
 chmod +x scripts/init.sh scripts/deploy.sh docker/entrypoint.sh
 ./scripts/init.sh       # заполнит .env (интерактивно)
-````
+```
 
 ### 3) Запуск
 
@@ -404,6 +404,28 @@ final class HealthController
 
 ```php
 $api->get('/health', \App\Controllers\Api\HealthController::class);
+```
+
+Проверка:
+
+```bash
+curl http://localhost:8080/api/health
+```
+
+### Telegram Mini App и `TelegramInitDataMiddleware`
+
+Добавьте проверку `initData` в `public/index.php` (требуется `BOT_TOKEN`):
+
+```php
+})->add(new \App\Middleware\TelegramInitDataMiddleware($config['bot_token'] ?: ''));
+```
+
+Примеры запросов:
+
+```bash
+curl http://localhost:8080/api/health -H "Authorization: tma <initData>"
+curl http://localhost:8080/api/health -H "X-Telegram-Init-Data: <initData>"
+curl "http://localhost:8080/api/health?initData=<initData>"
 ```
 
 ---

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -53,5 +53,18 @@ REDIS_DSN="tcp://127.0.0.1:6379"
 ],
 ```
 
-`initData` от Telegram WebApp может передаваться в заголовке `Authorization: tma <данные>`,
-в заголовке `X-Telegram-Init-Data` или параметре `initData` (query/body).
+## Проверка initData
+
+`TelegramInitDataMiddleware` валидирует подпись `initData` с помощью `BOT_TOKEN` из `.env`. Передавать данные можно тремя способами:
+
+1. Заголовок `Authorization: tma <initData>`
+2. Заголовок `X-Telegram-Init-Data: <initData>`
+3. Параметр `initData` в query или body
+
+Примеры:
+
+```bash
+curl http://localhost:8080/api/health -H "Authorization: tma <initData>"
+curl http://localhost:8080/api/health -H "X-Telegram-Init-Data: <initData>"
+curl "http://localhost:8080/api/health?initData=<initData>"
+```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ DB_USER="user"
 DB_PASS="pass"
 JWT_SECRET="secret"
 CORS_ORIGINS="*"
+BOT_TOKEN="0000000000:AA..."
 ```
+
+BOT_TOKEN — токен бота для проверки `initData` из Telegram WebApp.
 
 ---
 
@@ -58,6 +61,7 @@ composer serve
 
 * API: [http://localhost:8080/api/](http://localhost:8080/api/)\*
 * Dashboard: [http://localhost:8080/dashboard/](http://localhost:8080/dashboard/)\*
+* Health: [http://localhost:8080/api/health](http://localhost:8080/api/health)
 
 ---
 
@@ -67,6 +71,19 @@ composer serve
 * `JwtMiddleware` — защита API
 * `CsrfMiddleware` — защита Dashboard
 * `RateLimitMiddleware` — ограничение запросов
+* `TelegramInitDataMiddleware` — проверка `initData` Telegram WebApp
+
+---
+
+## 📱 Telegram Mini App
+
+Для запросов из Telegram WebApp передай `initData`, который проверяется через `TelegramInitDataMiddleware` и `BOT_TOKEN`.
+
+```bash
+curl http://localhost:8080/api/health -H "Authorization: tma <initData>"
+curl http://localhost:8080/api/health -H "X-Telegram-Init-Data: <initData>"
+curl "http://localhost:8080/api/health?initData=<initData>"
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- document health endpoint and TelegramInitDataMiddleware
- describe BOT_TOKEN and initData verification with examples
- add Unreleased section to changelog

## Testing
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*
- `composer cs` *(fails: php-cs-fixer: not found)*
- `composer tests` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86bf44af8832d9dafa5c4249621ed