### PR TITLE
Add API controllers and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, intl, pdo_sqlite
+      - run: composer install --no-interaction --no-progress
+      - run: composer cs
+      - run: composer analyse
+      - run: vendor/bin/phpunit

--- a/app/Controllers/Api/ItemsController.php
+++ b/app/Controllers/Api/ItemsController.php
@@ -5,16 +5,16 @@
 
 declare(strict_types=1);
 
-namespace App\Controllers\Dashboard;
+namespace App\Controllers\Api;
 
 use Psr\Http\Message\ServerRequestInterface as Req;
 use Psr\Http\Message\ResponseInterface as Res;
+use App\Helpers\Response;
 
-final class HomeController
+final class ItemsController
 {
-    public function index(Req $req, Res $res): Res
+    public function list(Req $req, Res $res): Res
     {
-        $res->getBody()->write('Dashboard OK');
-        return $res;
+        return Response::json($res, 200, ['items' => []]);
     }
 }

--- a/app/Controllers/Api/MeController.php
+++ b/app/Controllers/Api/MeController.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright (c) 2025. Vitaliy Kamelin <v.kamelin@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace App\Controllers\Api;
+
+use PDO;
+use Psr\Http\Message\ServerRequestInterface as Req;
+use Psr\Http\Message\ResponseInterface as Res;
+use App\Helpers\Response;
+
+final class MeController
+{
+    public function __construct(private PDO $pdo) {}
+
+    public function show(Req $req, Res $res): Res
+    {
+        $jwt = (array)$req->getAttribute('jwt');
+        $uid = (int)($jwt['uid'] ?? 0);
+        if ($uid <= 0) {
+            return Response::problem($res, 401, 'Unauthorized');
+        }
+        $stmt = $this->pdo->prepare('SELECT id, email, created_at FROM users WHERE id = ? LIMIT 1');
+        $stmt->execute([$uid]);
+        $u = $stmt->fetch();
+        if (!$u) {
+            return Response::problem($res, 404, 'User not found');
+        }
+        return Response::json($res, 200, ['user' => $u]);
+    }
+}

--- a/app/Controllers/Api/OrdersController.php
+++ b/app/Controllers/Api/OrdersController.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright (c) 2025. Vitaliy Kamelin <v.kamelin@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace App\Controllers\Api;
+
+use Psr\Http\Message\ServerRequestInterface as Req;
+use Psr\Http\Message\ResponseInterface as Res;
+use App\Helpers\Response;
+
+final class OrdersController
+{
+    public function create(Req $req, Res $res): Res
+    {
+        $data = (array)$req->getParsedBody();
+        if (empty($data['item_id'])) {
+            return Response::problem($res, 400, 'Validation error', ['errors' => ['item_id' => 'required']]);
+        }
+        return Response::json($res, 201, ['status' => 'created']);
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Smoke/ApiTest.php
+++ b/tests/Smoke/ApiTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Slim\Factory\AppFactory;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use App\Middleware\TelegramInitDataMiddleware;
+use App\Middleware\JwtMiddleware;
+use App\Middleware\RateLimitMiddleware;
+use App\Middleware\ErrorMiddleware;
+use App\Controllers\Api\MeController;
+use App\Helpers\Response;
+use Firebase\JWT\JWT;
+use PDO;
+
+final class ApiTest extends TestCase
+{
+    private string $botToken = 'TEST_TOKEN';
+    private string $jwtSecret = 'jwt-secret';
+
+    private function buildInitData(): string
+    {
+        $data = [
+            'auth_date' => '123',
+            'user' => json_encode(['id' => 1], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ];
+        ksort($data);
+        $check = [];
+        foreach ($data as $k => $v) {
+            $check[] = $k . '=' . $v;
+        }
+        $checkString = implode("\n", $check);
+        $secret = hash_hmac('sha256', $this->botToken, 'WebAppData', true);
+        $hash = hash_hmac('sha256', $checkString, $secret);
+        $data['hash'] = $hash;
+        return http_build_query($data);
+    }
+
+    private function createApp(PDO $pdo): \Slim\App
+    {
+        $app = AppFactory::create();
+        $app->addBodyParsingMiddleware();
+        $app->add(new ErrorMiddleware(true));
+        $app->group('/api', function (\Slim\Routing\RouteCollectorProxy $g) use ($pdo) {
+            $g->get('/health', fn($req, $res) => Response::json($res, 200, ['status' => 'ok']));
+            $g->group('', function (\Slim\Routing\RouteCollectorProxy $auth) use ($pdo) {
+                $auth->get('/me', function ($req, $res) use ($pdo) {
+                    return (new MeController($pdo))->show($req, $res);
+                });
+            })->add(new RateLimitMiddleware(['bucket' => 'ip', 'limit' => 60]))
+              ->add(new JwtMiddleware(['secret' => $this->jwtSecret, 'alg' => 'HS256', 'ttl' => 3600]));
+        })->add(new TelegramInitDataMiddleware($this->botToken));
+        return $app;
+    }
+
+    public function testHealthEndpoint(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $app = $this->createApp($pdo);
+        $init = $this->buildInitData();
+        $req = (new ServerRequestFactory())->createServerRequest('GET', '/api/health')
+            ->withHeader('X-Telegram-Init-Data', $init);
+        $res = $app->handle($req);
+        $this->assertSame(200, $res->getStatusCode());
+    }
+
+    public function testMeWithValidInitData(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE users(id INTEGER PRIMARY KEY, email TEXT, created_at TEXT);');
+        $pdo->exec("INSERT INTO users(id, email, created_at) VALUES(1, 'a@b.c', '2025-01-01');");
+        $app = $this->createApp($pdo);
+        $init = $this->buildInitData();
+        $token = JWT::encode(['uid' => 1, 'exp' => time() + 3600], $this->jwtSecret, 'HS256');
+        $req = (new ServerRequestFactory())->createServerRequest('GET', '/api/me')
+            ->withHeader('X-Telegram-Init-Data', $init)
+            ->withHeader('Authorization', 'Bearer ' . $token);
+        $res = $app->handle($req);
+        $this->assertSame(200, $res->getStatusCode());
+    }
+
+    public function testMeWithInvalidInitData(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE users(id INTEGER PRIMARY KEY, email TEXT, created_at TEXT);');
+        $pdo->exec("INSERT INTO users(id, email, created_at) VALUES(1, 'a@b.c', '2025-01-01');");
+        $app = $this->createApp($pdo);
+        $init = $this->buildInitData() . 'broken';
+        $token = JWT::encode(['uid' => 1, 'exp' => time() + 3600], $this->jwtSecret, 'HS256');
+        $req = (new ServerRequestFactory())->createServerRequest('GET', '/api/me')
+            ->withHeader('X-Telegram-Init-Data', $init)
+            ->withHeader('Authorization', 'Bearer ' . $token);
+        $res = $app->handle($req);
+        $this->assertSame(403, $res->getStatusCode());
+    }
+}

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use App\Helpers\Response;
+use Slim\Psr7\Response as Psr7Response;
+
+final class ResponseTest extends TestCase
+{
+    public function testJson(): void
+    {
+        $res = Response::json(new Psr7Response(), 200, ['foo' => 'bar']);
+        $this->assertSame(200, $res->getStatusCode());
+        $this->assertSame('application/json', $res->getHeaderLine('Content-Type'));
+        $this->assertSame(['foo' => 'bar'], json_decode((string)$res->getBody(), true));
+    }
+
+    public function testProblem(): void
+    {
+        $res = Response::problem(new Psr7Response(), 400, 'Error', ['detail' => 'oops']);
+        $this->assertSame(400, $res->getStatusCode());
+        $this->assertSame('application/problem+json', $res->getHeaderLine('Content-Type'));
+        $this->assertSame(
+            [
+                'type' => 'about:blank',
+                'title' => 'Error',
+                'status' => 400,
+                'detail' => 'oops',
+            ],
+            json_decode((string)$res->getBody(), true)
+        );
+    }
+}

--- a/tests/Unit/TelegramInitDataMiddlewareTest.php
+++ b/tests/Unit/TelegramInitDataMiddlewareTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Response as Psr7Response;
+use App\Middleware\TelegramInitDataMiddleware;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ServerRequestInterface as Req;
+use Psr\Http\Message\ResponseInterface as Res;
+
+final class TelegramInitDataMiddlewareTest extends TestCase
+{
+    private string $botToken = 'TEST_TOKEN';
+
+    private function buildInitData(array $user): string
+    {
+        $data = [
+            'auth_date' => '123',
+            'user' => json_encode($user, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ];
+        ksort($data);
+        $check = [];
+        foreach ($data as $k => $v) {
+            $check[] = $k . '=' . $v;
+        }
+        $checkString = implode("\n", $check);
+        $secret = hash_hmac('sha256', $this->botToken, 'WebAppData', true);
+        $hash = hash_hmac('sha256', $checkString, $secret);
+        $data['hash'] = $hash;
+        return http_build_query($data);
+    }
+
+    public function testValidInitDataPasses(): void
+    {
+        $middleware = new TelegramInitDataMiddleware($this->botToken);
+        $init = $this->buildInitData(['id' => 1, 'username' => 'test']);
+        $req = (new ServerRequestFactory())->createServerRequest('GET', '/')
+            ->withHeader('X-Telegram-Init-Data', $init);
+        $captured = null;
+        $handler = new class(&$captured) implements RequestHandlerInterface {
+            private $captured;
+            public function __construct(& $captured) { $this->captured =& $captured; }
+            public function handle(Req $request): Res
+            {
+                $this->captured = $request;
+                return new Psr7Response();
+            }
+        };
+        $res = $middleware->process($req, $handler);
+        $this->assertSame(200, $res->getStatusCode());
+        $this->assertInstanceOf(Req::class, $captured);
+        $this->assertSame(1, $captured->getAttribute('tg_user_id'));
+        $this->assertSame('test', $captured->getAttribute('tg_username'));
+    }
+
+    public function testInvalidInitDataFails(): void
+    {
+        $middleware = new TelegramInitDataMiddleware($this->botToken);
+        $init = $this->buildInitData(['id' => 1]);
+        $init .= 'broken';
+        $req = (new ServerRequestFactory())->createServerRequest('GET', '/')
+            ->withHeader('X-Telegram-Init-Data', $init);
+        $handler = new class implements RequestHandlerInterface {
+            public function handle(Req $request): Res
+            {
+                return new Psr7Response();
+            }
+        };
+        $res = $middleware->process($req, $handler);
+        $this->assertSame(403, $res->getStatusCode());
+        $this->assertStringContainsString('Invalid init data', (string)$res->getBody());
+    }
+}


### PR DESCRIPTION
## Summary
- return "Dashboard OK" from home page
- add API controllers for profile, items and orders
- cover Response helper and Telegram init data middleware with tests and smoke tests
- run code style, static analysis and PHPUnit in CI

## Testing
- `composer cs` *(fails: php-cs-fixer: not found)*
- `composer analyse` *(fails: phpstan: not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a86de2ab1c832d943e6b91822a5e00