### PR TITLE
chore: add env example and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,17 @@
 # === База данных ===
-DB_DSN="mysql:host=127.0.0.1;dbname=app;charset=utf8mb4"
-DB_USER="root"
-DB_PASS="secret"
+DB_DSN="mysql:host=127.0.0.1;dbname=app;charset=utf8mb4" # строка подключения
+DB_USER="root"                                            # пользователь БД
+DB_PASS="secret"                                          # пароль БД
+
+# === JWT токены ===
+JWT_SECRET="change_me"                                    # секретный ключ JWT
 
 # === CORS ===
-CORS_ORIGINS="*"
+CORS_ORIGINS="*"                                          # список разрешённых origin через запятую
+
+# === Rate limit ===
+RATE_LIMIT_BUCKET=ip                                       # тип лимита: ip или user
+RATE_LIMIT=60                                              # запросов в минуту
 
 # === Telegram ===
-BOT_TOKEN="0000000000:AA..." # токен бота
+BOT_TOKEN="0000000000:AA..."                              # токен Telegram-бота

--- a/README.md
+++ b/README.md
@@ -39,12 +39,14 @@ cp .env.example .env
 Укажи в `.env`:
 
 ```
-DB_DSN="mysql:host=127.0.0.1;dbname=app;charset=utf8mb4"
-DB_USER="user"
-DB_PASS="pass"
-JWT_SECRET="secret"
-CORS_ORIGINS="*"
-BOT_TOKEN="0000000000:AA..."
+DB_DSN="mysql:host=127.0.0.1;dbname=app;charset=utf8mb4" # строка подключения к БД
+DB_USER="user"                                           # пользователь БД
+DB_PASS="pass"                                           # пароль БД
+JWT_SECRET="secret"                                      # секретный ключ JWT
+CORS_ORIGINS="*"                                         # разрешённые origin через запятую
+RATE_LIMIT_BUCKET=ip                                     # тип лимита: ip или user
+RATE_LIMIT=60                                            # запросов в минуту
+BOT_TOKEN="0000000000:AA..."                            # токен Telegram-бота
 ```
 
 BOT_TOKEN — токен бота для проверки `initData` из Telegram WebApp.


### PR DESCRIPTION
## Summary
- add comprehensive `.env.example` with DB, JWT, CORS, rate limit, and bot token settings
- document env variables in README and mention copying sample env file

## Testing
- `composer tests` *(fails: phpunit: not found)*
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a86f59b90c832da9b325917b62e2b1