### PR TITLE
refactor: read env vars from $_ENV

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -44,12 +44,12 @@ REDIS_DSN="tcp://127.0.0.1:6379"
 В `app/Config/config.php`:
 
 ```php
-'bot_token' => getenv('BOT_TOKEN'),
+'bot_token' => $_ENV['BOT_TOKEN'] ?? null,
 
 'db' => [
-    'dsn'  => getenv('DB_DSN'),
-    'user' => getenv('DB_USER'),
-    'pass' => getenv('DB_PASS'),
+    'dsn'  => $_ENV['DB_DSN'] ?? null,
+    'user' => $_ENV['DB_USER'] ?? null,
+    'pass' => $_ENV['DB_PASS'] ?? null,
 ],
 ```
 

--- a/app/Config/config.php
+++ b/app/Config/config.php
@@ -2,15 +2,19 @@
 
 declare(strict_types=1);
 
+use Dotenv\Dotenv;
+
+Dotenv::createImmutable(dirname(__DIR__, 2))->safeLoad();
+
 return [
-    'app_env' => getenv('APP_ENV') ?: 'prod',
-    'debug' => (bool)(getenv('APP_DEBUG') ?: false),
-    'bot_token' => getenv('BOT_TOKEN'),
+    'app_env' => $_ENV['APP_ENV'] ?? 'prod',
+    'debug' => (bool)($_ENV['APP_DEBUG'] ?? false),
+    'bot_token' => $_ENV['BOT_TOKEN'] ?? null,
 
     'db' => [
-        'dsn' => getenv('DB_DSN'),   // 'mysql:host=127.0.0.1;dbname=app;charset=utf8mb4'
-        'user' => getenv('DB_USER'),
-        'pass' => getenv('DB_PASS'),
+        'dsn' => $_ENV['DB_DSN'] ?? null,   // 'mysql:host=127.0.0.1;dbname=app;charset=utf8mb4'
+        'user' => $_ENV['DB_USER'] ?? null,
+        'pass' => $_ENV['DB_PASS'] ?? null,
         'opts' => [
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
@@ -20,13 +24,13 @@ return [
     ],
     
     'jwt' => [
-        'secret' => getenv('JWT_SECRET'),
+        'secret' => $_ENV['JWT_SECRET'] ?? null,
         'alg' => 'HS256',
         'ttl' => 3600,
     ],
     
     'cors' => [
-        'origins' => explode(',', getenv('CORS_ORIGINS') ?: ''),
+        'origins' => explode(',', $_ENV['CORS_ORIGINS'] ?? ''),
         'methods' => 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
         'headers' => 'Authorization,Content-Type,X-Request-Id',
     ],

--- a/app/Middleware/ContentSecurityPolicyMiddleware.php
+++ b/app/Middleware/ContentSecurityPolicyMiddleware.php
@@ -18,10 +18,10 @@ class ContentSecurityPolicyMiddleware
         ?string $img = null,
         ?string $connect = null,
     ) {
-        $scriptSrc = $this->buildSources($script ?? getenv('CSP_SCRIPT_SRC') ?: '');
-        $styleSrc = $this->buildSources($style ?? getenv('CSP_STYLE_SRC') ?: '', true);
-        $imgSrc = $this->buildSources($img ?? getenv('CSP_IMG_SRC') ?: '');
-        $connectSrc = $this->buildSources($connect ?? getenv('CSP_CONNECT_SRC') ?: '');
+        $scriptSrc = $this->buildSources($script ?? ($_ENV['CSP_SCRIPT_SRC'] ?? ''));
+        $styleSrc = $this->buildSources($style ?? ($_ENV['CSP_STYLE_SRC'] ?? ''), true);
+        $imgSrc = $this->buildSources($img ?? ($_ENV['CSP_IMG_SRC'] ?? ''));
+        $connectSrc = $this->buildSources($connect ?? ($_ENV['CSP_CONNECT_SRC'] ?? ''));
 
         $this->policy = sprintf(
             "default-src 'self'; connect-src %s; img-src %s data:; script-src %s; style-src %s; frame-ancestors 'none'",

--- a/app/Middleware/CorsMiddleware.php
+++ b/app/Middleware/CorsMiddleware.php
@@ -19,7 +19,7 @@ class CorsMiddleware
 
     public function __construct(?string $origins = null, ?ResponseFactory $responseFactory = null)
     {
-        $origins = $origins ?? getenv('CORS_ORIGIN') ?: '';
+        $origins = $origins ?? ($_ENV['CORS_ORIGIN'] ?? '');
         $this->allowedOrigins = array_filter(array_map('trim', explode(',', $origins)));
         $this->responseFactory = $responseFactory ?? new ResponseFactory();
     }


### PR DESCRIPTION
## Summary
- use $_ENV instead of getenv for configuration and middlewares
- load .env variables before reading config
- document $_ENV usage in environment guide

## Testing
- `composer cs` *(fails: php-cs-fixer: not found)*
- `composer tests` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a872c0c920832d81b0270876d15185