### PR TITLE
Use CorsMiddleware for CORS handling

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -5,6 +5,7 @@ use Slim\Factory\AppFactory;
 use Psr\Http\Message\ServerRequestInterface as Req;
 use Psr\Http\Message\ResponseInterface as Res;
 use Dotenv\Dotenv;
+use App\Middleware\CorsMiddleware;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -23,19 +24,11 @@ $app->addBodyParsingMiddleware();
 $app->add(new \App\Middleware\ErrorMiddleware($config['debug']));
 
 // === CORS для API ===
-$app->options('/{routes:.+}', fn(Req $r, Res $w)=>$w);
-$app->add(function (Req $req, $handler) use ($config) {
-    $res = $handler->handle($req);
-    $origin = $req->getHeaderLine('Origin');
-    if ($origin && (empty($config['cors']['origins']) || in_array($origin, $config['cors']['origins'], true))) {
-        return $res
-            ->withHeader('Access-Control-Allow-Origin', $origin)
-            ->withHeader('Access-Control-Allow-Credentials', 'true')
-            ->withHeader('Access-Control-Allow-Headers', $config['cors']['headers'])
-            ->withHeader('Access-Control-Allow-Methods', $config['cors']['methods']);
-    }
-    return $res;
-});
+$app->add(new CorsMiddleware(
+    $config['cors']['origins'],
+    $config['cors']['methods'],
+    $config['cors']['headers'],
+));
 
 // === Группы маршрутов ===
 


### PR DESCRIPTION
## Summary
- remove inline CORS handler
- enable configurable CORS middleware

## Testing
- `composer tests` *(fails: phpunit: not found)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `composer analyse` *(fails: phpstan not found)*
- `php -l public/index.php app/Middleware/CorsMiddleware.php`


------
https://chatgpt.com/codex/tasks/task_e_68a87c4487e4832d848dc7e2c51cf696