### PR TITLE
refactor: unify error handling

### DIFF
--- a/app/Exceptions/ValidationException.php
+++ b/app/Exceptions/ValidationException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use Exception;
+use Throwable;
+
+final class ValidationException extends Exception
+{
+    public function __construct(private array $errors = [], string $message = 'Validation failed', int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/app/Middleware/ErrorMiddleware.php
+++ b/app/Middleware/ErrorMiddleware.php
@@ -7,24 +7,44 @@ declare(strict_types=1);
 
 namespace App\Middleware;
 
+use App\Handlers\ApiErrorHandler;
 use Psr\Http\Message\ResponseInterface as Res;
 use Psr\Http\Message\ServerRequestInterface as Req;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface as Handler;
-use App\Helpers\Response;
+use Slim\Exception\HttpException;
+use Slim\Psr7\Factory\ResponseFactory;
 use Throwable;
 
 final class ErrorMiddleware implements MiddlewareInterface
 {
-    public function __construct(private bool $debug) {}
-    
+    private ApiErrorHandler $apiHandler;
+    private ResponseFactory $responseFactory;
+
+    public function __construct(private bool $debug, ?ApiErrorHandler $apiHandler = null, ?ResponseFactory $responseFactory = null)
+    {
+        $this->apiHandler = $apiHandler ?? new ApiErrorHandler();
+        $this->responseFactory = $responseFactory ?? new ResponseFactory();
+    }
+
     public function process(Req $req, Handler $handler): Res
     {
         try {
             return $handler->handle($req);
         } catch (Throwable $e) {
-            $extra = $this->debug ? ['trace' => $e->getTraceAsString()] : [];
-            return Response::problem(new \Slim\Psr7\Response(), 500, 'Internal Server Error', $extra);
+            $path = $req->getUri()->getPath();
+            $accept = $req->getHeaderLine('Accept');
+            $wantsJson = str_starts_with($path, '/api') || str_contains($accept, 'application/json');
+
+            if ($wantsJson) {
+                return $this->apiHandler->handle($e);
+            }
+
+            $status = $e instanceof HttpException ? $e->getCode() : 500;
+            $message = $this->debug ? $e->getMessage() : 'Internal Server Error';
+            $response = $this->responseFactory->createResponse($status);
+            $response->getBody()->write($message);
+            return $response->withHeader('Content-Type', 'text/plain');
         }
     }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -8,7 +8,6 @@ use Dotenv\Dotenv;
 use App\Middleware\CorsMiddleware;
 use App\Middleware\RequestIdMiddleware;
 use App\Middleware\RequestSizeLimitMiddleware;
-use App\Middleware\JsonErrorMiddleware;
 use App\Middleware\ContentSecurityPolicyMiddleware;
 use App\Middleware\XFrameOptionsMiddleware;
 
@@ -26,7 +25,6 @@ $app = AppFactory::create();
 $app->add(new RequestIdMiddleware());
 $app->add(new RequestSizeLimitMiddleware($config['request_size_limit']));
 $app->addBodyParsingMiddleware();
-$app->add(new JsonErrorMiddleware());
 $app->add(new ContentSecurityPolicyMiddleware());
 $app->add(new XFrameOptionsMiddleware());
 $app->add(new CorsMiddleware(


### PR DESCRIPTION
## Summary
- centralize API error responses in new `ApiErrorHandler`
- update `ErrorMiddleware` to respond with JSON for API requests and plain text elsewhere
- drop legacy `JsonErrorMiddleware` and expose simple `ValidationException`

## Testing
- `composer test` *(fails: phpunit not found)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a87e9d1920832da05a2222cf802130