### PR TITLE
Use environment-driven Phinx configuration

### DIFF
--- a/app/Console/Command.php
+++ b/app/Console/Command.php
@@ -2,6 +2,8 @@
 
 namespace App\Console;
 
+use Dotenv\Dotenv;
+
 abstract class Command
 {
     public string $signature = '';
@@ -17,6 +19,8 @@ abstract class Command
      */
     public function run(array $arguments, Kernel $kernel): int
     {
+        Dotenv::createImmutable(dirname(__DIR__, 2))->safeLoad();
+
         return $this->handle($arguments, $kernel);
     }
 }

--- a/app/Console/Commands/MigrateRollbackCommand.php
+++ b/app/Console/Commands/MigrateRollbackCommand.php
@@ -26,10 +26,11 @@ class MigrateRollbackCommand extends Command
         $command->setApplication($application);
 
         $config = dirname(__DIR__, 3) . '/phinx.php';
+        $env = $_ENV['APP_ENV'] ?? 'development';
 
         $input = new ArrayInput([
             '--configuration' => $config,
-            '--environment' => 'default',
+            '--environment' => $env,
         ]);
         $output = new ConsoleOutput();
 

--- a/app/Console/Commands/MigrateRunCommand.php
+++ b/app/Console/Commands/MigrateRunCommand.php
@@ -26,10 +26,11 @@ class MigrateRunCommand extends Command
         $command->setApplication($application);
 
         $config = dirname(__DIR__, 3) . '/phinx.php';
+        $env = $_ENV['APP_ENV'] ?? 'development';
 
         $input = new ArrayInput([
             '--configuration' => $config,
-            '--environment' => 'default',
+            '--environment' => $env,
         ]);
         $output = new ConsoleOutput();
 

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     "cs:fix": "php-cs-fixer fix",
     "tests": "phpunit",
     "analyse": "phpstan analyse --memory-limit=1G",
-    "migrate": "vendor/bin/phinx migrate",
+    "migrate": "vendor/bin/phinx migrate -c phinx.php",
     "build:css": "npx tailwindcss -c tailwind.config.js -i assets/css/tailwind.css -o public/assets/css/tailwind.css --minify",
     "arch:check": "php tools/ci/validate-architecture.php"
   },

--- a/phinx.php
+++ b/phinx.php
@@ -2,10 +2,19 @@
 
 declare(strict_types=1);
 
-$config = require __DIR__ . '/app/Config/config.php';
-$db = $config['db'];
-$dsn = $db['dsn'] ?? '';
+use Dotenv\Dotenv;
+
+Dotenv::createImmutable(__DIR__)->safeLoad();
+
+$dsn = $_ENV['DB_DSN'] ?? '';
 $adapter = explode(':', $dsn, 2)[0] ?: 'mysql';
+
+$db = [
+    'adapter' => $adapter,
+    'dsn' => $dsn,
+    'user' => $_ENV['DB_USER'] ?? null,
+    'pass' => $_ENV['DB_PASS'] ?? null,
+];
 
 return [
     'paths' => [
@@ -14,12 +23,9 @@ return [
     ],
     'environments' => [
         'default_migration_table' => 'phinxlog',
-        'default_environment' => 'default',
-        'default' => [
-            'adapter' => $adapter,
-            'dsn' => $dsn,
-            'user' => $db['user'] ?? null,
-            'pass' => $db['pass'] ?? null,
-        ],
+        'default_environment' => $_ENV['APP_ENV'] ?? 'development',
+        'development' => $db,
+        'production' => $db,
     ],
 ];
+


### PR DESCRIPTION
## Summary
- load `.env` and define development/production environments in `phinx.php`
- load environment variables for console commands and use `APP_ENV` when running migrations
- ensure Composer migrate script references the new `phinx.php`

## Testing
- `composer run tests` *(fails: phpunit: not found)*
- `composer migrate` *(fails: vendor/bin/phinx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a88b603004832d835e94ce6b8428b6