### PR TITLE
refactor: replace logMessage with Logger

### DIFF
--- a/app/Helpers/Database.php
+++ b/app/Helpers/Database.php
@@ -66,7 +66,7 @@ class Database
         try {
             return ((int)$pdo->query('SELECT 1')->fetchColumn() === 1);
         } catch (PDOException $e) {
-            logMessage("Ping не прошёл: {$e->getMessage()}", 'warning', $e);
+            Logger::warning("Ping не прошёл: {$e->getMessage()}", ['exception' => $e]);
             return false;
         }
     }
@@ -97,10 +97,9 @@ class Database
                 return $pdo;
             } catch (PDOException $e) {
                 $lastException = $e;
-                logMessage(
+                Logger::warning(
                     "Попытка #{$attempt} подключения не удалась: {$e->getMessage()}",
-                    'warning',
-                    $e
+                    ['exception' => $e]
                 );
                 // Ждём перед следующим повтором, если он будет
                 if ($attempt < self::MAX_TRIES) {
@@ -108,12 +107,11 @@ class Database
                 }
             }
         }
-        
+
         // Все попытки исчерпаны — фатальная ошибка
-        logMessage(
+        Logger::error(
             "Не удалось подключиться к БД после " . self::MAX_TRIES . " попыток",
-            'error',
-            $lastException
+            ['exception' => $lastException]
         );
         throw new RuntimeException('Невозможно подключиться к базе данных');
     }

--- a/app/Helpers/Push.php
+++ b/app/Helpers/Push.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Helpers;
 
-require_once __DIR__ . '/../init.php';
-
 use RuntimeException;
 use Throwable;
 
@@ -408,7 +406,10 @@ class Push
                         // ID записанного сообщения
                         $id = $db->lastInsertId();
                     } catch (Throwable $e) {
-                        logMessage("Не удалось добавить в очередь пуш в Телеграм. {$e->getMessage()}.", 'error');
+                        Logger::error(
+                            "Не удалось добавить в очередь пуш в Телеграм. {$e->getMessage()}.",
+                            ['exception' => $e]
+                        );
                         return false;
                     }
                     
@@ -454,7 +455,10 @@ class Push
                 return true;
             }
         } catch (Throwable $e) {
-            logMessage("Не удалось добавить в очередь пуш в Телеграм.", 'error', $e);
+            Logger::error(
+                "Не удалось добавить в очередь пуш в Телеграм.",
+                ['exception' => $e]
+            );
         }
         
         return false;


### PR DESCRIPTION
## Summary
- drop manual init include
- use central Logger for push queuing and database connection errors

## Testing
- `composer tests` *(fails: phpunit not found)*
- `composer install --ignore-platform-req=ext-redis -n --no-progress` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a898ff4e58832d8541868d9674da2f