### PR TITLE
Add env helper and update autoload

### DIFF
--- a/app/Helpers/env.php
+++ b/app/Helpers/env.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+if (!function_exists('env')) {
+    /**
+     * Retrieves an environment variable or returns default value.
+     *
+     * @param string $key     The environment variable name
+     * @param mixed  $default The default value if key not found
+     *
+     * @return mixed
+     */
+    function env(string $key, mixed $default = null): mixed
+    {
+        $value = $_ENV[$key] ?? getenv($key);
+
+        if ($value === false || $value === null || $value === '') {
+            return $default;
+        }
+
+        $lower = strtolower((string)$value);
+        return match ($lower) {
+            'true', '(true)' => true,
+            'false', '(false)' => false,
+            'empty', '(empty)' => '',
+            'null', '(null)' => null,
+            default => $value,
+        };
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,14 @@
   ],
   "license": "proprietary",
   "homepage": "https://devbot.pro",
-  "keywords": ["telegram", "bot", "api", "dashboard", "slim", "php"],
+  "keywords": [
+    "telegram",
+    "bot",
+    "api",
+    "dashboard",
+    "slim",
+    "php"
+  ],
   "require": {
     "php": "^8.3",
     "ext-zip": "*",
@@ -47,9 +54,11 @@
   "autoload": {
     "psr-4": {
       "App\\": "app/"
-    }
+    },
+    "files": [
+      "app/Helpers/env.php"
+    ]
   },
-
   "scripts": {
     "serve": "php -S 0.0.0.0:8080 -t public",
     "cs": "php-cs-fixer fix --dry-run --diff",


### PR DESCRIPTION
## Summary
- add global `env()` helper for environment lookups
- register helper in Composer autoload configuration

## Testing
- `composer tests` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a89ac58ee0832d90b087e63de348fc