### PR TITLE
Introduce Config singleton and update workers

### DIFF
--- a/app/Config.php
+++ b/app/Config.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+/**
+ * Simple configuration loader providing access to values
+ * from the application config array and environment variables.
+ */
+final class Config
+{
+    /**
+     * Loaded configuration values.
+     *
+     * @var array<string, mixed>
+     */
+    private array $data;
+
+    private static ?self $instance = null;
+
+    /**
+     * @phpstan-ignore-next-line
+     */
+    private function __construct()
+    {
+        /** @var array<string, mixed> $config */
+        $config = require __DIR__ . '/Config/config.php';
+        $this->data = $config;
+    }
+
+    public static function getInstance(): self
+    {
+        return self::$instance ??= new self();
+    }
+
+    /**
+     * Retrieve a configuration value.
+     *
+     * Environment variables take precedence over values from the
+     * configuration array. If the key is not found, the provided default
+     * value is returned.
+     *
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        if (array_key_exists($key, $_ENV)) {
+            return $_ENV[$key];
+        }
+
+        return $this->data[$key] ?? $default;
+    }
+}

--- a/workers/gpt.php
+++ b/workers/gpt.php
@@ -10,9 +10,7 @@ use App\Support\RedisKeyHelper;
 
 /** @var \Slim\App $app */
 $app = require __DIR__ . '/../bootstrap.php';
-/** @var \Psr\Container\ContainerInterface $container */
-$container = $app->getContainer();
-$config = $container->get(Config::class);
+$config = Config::getInstance();
 
 $redis = null;
 try {

--- a/workers/longpolling.php
+++ b/workers/longpolling.php
@@ -15,9 +15,7 @@ use RuntimeException;
 
 /** @var \Slim\App $app */
 $app = require __DIR__ . '/../bootstrap.php';
-/** @var \Psr\Container\ContainerInterface $container */
-$container = $app->getContainer();
-$config = $container->get(Config::class);
+$config = Config::getInstance();
 
 $db = Db::get();
 try {

--- a/workers/telegram.php
+++ b/workers/telegram.php
@@ -14,9 +14,7 @@ use Longman\TelegramBot\Telegram;
 
 /** @var \Slim\App $app */
 $app = require __DIR__ . '/../bootstrap.php';
-/** @var \Psr\Container\ContainerInterface $container */
-$container = $app->getContainer();
-$config = $container->get(Config::class);
+$config = Config::getInstance();
 
 try {
     if ($_ENV['TELEGRAM_API_SERVER'] === 'local') {


### PR DESCRIPTION
## Summary
- add `App\Config` class for unified environment/config access
- update worker scripts to use the Config singleton directly

## Testing
- `composer tests` *(fails: phpunit not found)*
- `composer install --ignore-platform-req=ext-redis` *(fails: GitHub API requires token)*

------
https://chatgpt.com/codex/tasks/task_e_68a89da921e8832dae9b89cbbcb5472c