### PR TITLE
refactor: use helpers for db and redis in workers

### DIFF
--- a/workers/gpt.php
+++ b/workers/gpt.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use App\Logger;
 use App\Services\GPTService;
-use App\Services\RedisService;
+use App\Helpers\RedisHelper;
 use App\Config;
 use App\Support\RedisKeyHelper;
 
@@ -14,8 +14,8 @@ $config = Config::getInstance();
 
 $redis = null;
 try {
-    $redis = RedisService::get();
-} catch (RuntimeException $e) {
+    $redis = RedisHelper::getInstance();
+} catch (\RedisException $e) {
     Logger::error('Redis connection failed: ' . $e->getMessage());
     exit();
 }

--- a/workers/purge_refresh_tokens.php
+++ b/workers/purge_refresh_tokens.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 require __DIR__ . '/../bootstrap.php';
 
 use App\Domain\RefreshTokenTable;
-use App\Services\Db;
+use App\Helpers\Database;
 
-$repo = new RefreshTokenTable(Db::get());
+$repo = new RefreshTokenTable(Database::getInstance());
 $count = $repo->deleteExpired();
 echo "Purged {$count} expired tokens." . PHP_EOL;

--- a/workers/telegram.php
+++ b/workers/telegram.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 use App\Logger;
-use App\Services\Db;
-use App\Services\RedisService;
+use App\Helpers\Database;
+use App\Helpers\RedisHelper;
 use App\Telemetry;
 use App\Config;
 use App\Support\RedisKeyHelper;
@@ -42,10 +42,10 @@ $perWorkerRps = max(1, intdiv($globalMaxRps, $workerCount));
  */
 function dispatchScheduledMessages(): void
 {
-    $db = Db::get();
+    $db = Database::getInstance();
     try {
-        $redis = RedisService::get();
-    } catch (RuntimeException $e) {
+        $redis = RedisHelper::getInstance();
+    } catch (\RedisException $e) {
         Logger::error('Redis connection failed: ' . $e->getMessage());
         return;
     }
@@ -113,10 +113,10 @@ function runWorker(): void
         $startTime = microtime(true);
         $messagesProcessed = 0;
 
-        $db = Db::get();
+        $db = Database::getInstance();
         try {
-            $redis = RedisService::get();
-        } catch (RuntimeException $e) {
+            $redis = RedisHelper::getInstance();
+        } catch (\RedisException $e) {
             Logger::error('Redis connection failed: ' . $e->getMessage());
             return;
         }
@@ -282,10 +282,10 @@ function runWorker(): void
  */
 function saveUpdate(int $id, ServerResponse $response, string $queueKey): void
 {
-    $db = Db::get();
+    $db = Database::getInstance();
     try {
-        $redis = RedisService::get();
-    } catch (RuntimeException $e) {
+        $redis = RedisHelper::getInstance();
+    } catch (\RedisException $e) {
         Logger::error('Redis connection failed: ' . $e->getMessage());
         return;
     }


### PR DESCRIPTION
## Summary
- refactor workers to use Helpers\Database and Helpers\RedisHelper
- drop legacy service and path classes

## Testing
- `composer tests` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a89f0936b4832db9155cf5283070bb