### PR TITLE
docs: expand coding standards

### DIFF
--- a/docs/coding_standards.md
+++ b/docs/coding_standards.md
@@ -1,16 +1,62 @@
 # Стандарты кодирования
 
-## Общие правила
-- PSR-12
-- DocBlocks
+## PSR-12 и строгая типизация
+- Соблюдай PSR-12.
+- В начале каждого PHP-файла указывай `declare(strict_types=1)`.
 
-## PHP
-- Именование классов
-- Исключения
+## PHPDoc и документирование
+- Документируй все публичные классы, методы и свойства.
+- PHPDoc используй только там, где типы не очевидны из кода.
+- Пример оформления:
+
+```php
+/**
+ * Контроллер для работы с пользователями.
+ *
+ * Обрабатывает маршруты /api/users.
+ */
+final class UsersController
+{
+    /** PDO-подключение к базе данных */
+    private PDO $pdo;
+
+    /** Конфиг JWT (secret, alg, ttl) */
+    private array $jwtCfg;
+
+    /** Максимальное количество пользователей в выдаче */
+    private const MAX_USERS = 100;
+
+    /**
+     * Возвращает список пользователей.
+     *
+     * @param Req $req HTTP-запрос
+     * @param Res $res HTTP-ответ
+     * @return Res JSON с пользователями
+     */
+    public function list(Req $req, Res $res): Res
+    {
+        // нормализуем email перед проверкой
+        $email = strtolower(trim($data['email'] ?? ''));
+
+        return $res;
+    }
+}
+```
+
+## Примеры комментариев к SQL
+```php
+// Получаем последних 100 пользователей по дате создания
+$stmt = $pdo->query('SELECT id, email, created_at FROM users ORDER BY created_at DESC LIMIT 100');
+```
+
+## TODO / FIXME
+- `// TODO:` для отложенных задач.
+- `// FIXME:` для временного или некорректного решения.
 
 ## JS/TS
 - eslint
 - prettier
 
 ## Git
-- Формат коммитов
+- Сообщения коммитов в формате `<type>: <summary>` (`feat`, `fix`, `docs`, `refactor`, `test`, `chore`).
+- Перед коммитом запускай `composer cs` и `composer tests`; коммит должен содержать только отформатированный и проверенный код.


### PR DESCRIPTION
## Summary
- document PSR-12 usage, strict types and PHPDoc rules
- add examples for comments, SQL, TODO/FIXME
- state commit message prefixes and formatting checks

## Testing
- `composer tests` *(fails: phpunit not found)*
- `composer install` *(fails: missing ext-redis and network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c4cefca4832da08b6ac71876aadb