### PR TITLE
docs: expand deployment configuration

### DIFF
--- a/docs/deployment_configuration.md
+++ b/docs/deployment_configuration.md
@@ -1,14 +1,40 @@
 # Конфигурация деплоя
 
-## Среды
-- Dev
-- Staging
-- Prod
-
 ## Переменные окружения
-- DB_HOST
-- REDIS_URL
+- `DB_DSN` — строка подключения к базе данных
+- `DB_USER` — пользователь БД
+- `DB_PASS` — пароль БД
+- `JWT_SECRET` — секретный ключ для выпуска JWT
+- `CORS_ORIGINS` — список разрешённых origin
+- `RATE_LIMIT_BUCKET` — тип лимита (`ip` или `user`)
+- `RATE_LIMIT` — количество запросов в минуту
+- `REQUEST_SIZE_LIMIT` — максимальный размер тела запроса
+- `BOT_TOKEN` — токен Telegram‑бота
+
+## Среды
+
+### Dev
+- запуск: Docker Compose (`docker compose up -d`)
+- пример значений:
+  - `DB_DSN`: `mysql:host=db;dbname=app_dev;charset=utf8mb4`
+  - `CORS_ORIGINS`: `*`
+  - `RATE_LIMIT`: `0` (без ограничений)
+
+### Staging
+- запуск: Kubernetes (`kubectl apply -f k8s/staging/`)
+- пример значений:
+  - `DB_DSN`: `mysql:host=db;dbname=app_staging;charset=utf8mb4`
+  - `CORS_ORIGINS`: `https://staging.example.com`
+  - `RATE_LIMIT`: `60`
+
+### Prod
+- запуск: Kubernetes (`kubectl apply -f k8s/prod/`)
+- пример значений:
+  - `DB_DSN`: `mysql:host=db;dbname=app;charset=utf8mb4`
+  - `CORS_ORIGINS`: `https://example.com`
+  - `RATE_LIMIT`: `60`
 
 ## Деплой
-- Docker compose
-- kubectl apply
+1. `composer install --no-dev`
+2. `vendor/bin/phinx migrate` — запуск миграций
+3. перезапустить воркеры (например, `supervisorctl restart workers:*` или `kubectl rollout restart deployment/worker`)


### PR DESCRIPTION
## Summary
- document required environment variables from `.env.example`
- describe dev/staging/prod configuration differences and deployment steps

## Testing
- `composer cs` *(fails: php-cs-fixer: not found)*
- `composer tests` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c5bd3604832d9d8d6d2fd75df18e