### PR TITLE
docs: expand observability guidance

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,16 +1,18 @@
 # Наблюдаемость
 
 ## Логирование
-- Структура логов
-- Ротация
+- Используется обёртка `App\\Helpers\\Logger` поверх Monolog.
+- Записи формируются в формате JSON.
+- Перед сохранением редактируются PII (пароли, токены и т.д.).
+- Файлы хранятся в `storage/logs` и ротируются ежедневно.
 
 ## Метрики
-- CPU
-- Requests/sec
+- `workers/telegram.php`: `Telemetry::incrementTelegramSent`, `Telemetry::recordTelegramSendFailure`, `Telemetry::setTelegramQueueSize`, `Telemetry::setDlqSize`.
+- `App\\Helpers\\GPTService`: `Telemetry::setGptBreakerState`, `Telemetry::observeGptResponseTime`.
 
 ## Трассировка
-- OpenTelemetry
+- Интеграция с OpenTelemetry через зависимость Composer `open-telemetry/opentelemetry`.
 
 ## Алертинг
-- Slack
-- Email
+- Slack — уведомления при высоком уровне ошибок или росте DLQ.
+- Email — уведомления о длительной недоступности сервисов и замедлении ответов.


### PR DESCRIPTION
## Summary
- detail custom Logger JSON output, PII scrubbing, and storage location
- document Telemetry metrics from worker and GPT service
- note OpenTelemetry tracing and alerting criteria

## Testing
- `composer tests` *(fails: phpunit: not found)*
- `composer install --ignore-platform-req=ext-redis` *(fails: GitHub 403 during package download)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cdb8cde0832d888d2fa1807dbafe