### PR TITLE
docs: update runbook with worker and db procedures

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,8 +1,26 @@
 # Runbook (операционный гайд)
 
 ## Проверка статуса
+
+### Приложение
 ```bash
 kubectl get pods
+```
+
+### Воркеры
+```bash
+ps aux | grep workers/telegram.php
+tail -n 100 storage/logs/*.log
+```
+
+### Redis
+```bash
+redis-cli ping
+```
+
+### MySQL
+```bash
+mysqladmin ping
 ```
 
 ## Перезапуск сервиса
@@ -10,5 +28,19 @@ kubectl get pods
 kubectl rollout restart deployment app
 ```
 
+## Перезапуск воркеров
+```bash
+pkill -f workers/telegram.php
+php workers/telegram.php &
+```
+
+## Очистка очередей и логов
+```bash
+redis-cli FLUSHALL
+rm -f storage/logs/*.log
+```
+
 ## Типовые инциденты
-- Ошибка 500 → проверить логи
+- Ошибка 500 → проверить `storage/logs/*.log`, при необходимости перезапустить сервис
+- Переполнение очереди → очистить очередь в Redis и перезапустить воркеры
+- Сбой БД → проверить доступность MySQL (`mysqladmin ping`) и восстановить её


### PR DESCRIPTION
## Summary
- document worker, Redis and MySQL status checks
- add procedures for restarting workers, clearing queues and logs
- outline common incident responses for 500 errors, queue overflow and DB failures

## Testing
- `composer tests` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d023daa8832da272b383d9ee742f