### PR TITLE
docs: expand security guidelines

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,16 +1,18 @@
 # Безопасность
 
 ## Аутентификация
-- JWT
-- OAuth2
+- JWT через `JwtMiddleware`
+- Проверка `initData` от Telegram
 
 ## Авторизация
-- RBAC
+- Роли не реализованы, выполняется только идентификация
 
 ## Данные
-- Шифрование паролей
-- TLS
+- Пароли хешируются через `password_hash`
+- Трафик шифруется TLS
+- Ограничение размера тела запроса (`RequestSizeLimitMiddleware`)
 
 ## Зависимости
+- Composer Audit для поиска уязвимостей
+- Регулярные обновления библиотек Telegram и Monolog
 - Renovate
-- Composer audit


### PR DESCRIPTION
## Summary
- Document JWT authentication with `JwtMiddleware` and Telegram `initData` verification
- Note that authorization roles are not implemented yet
- Describe password hashing, TLS usage, request body size limits, and dependency auditing/upgrades

## Testing
- `composer install --ignore-platform-req=ext-redis` *(fails: requires GitHub token/403)*
- `composer tests` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d10d651c832dac0f2fbfacccd577