### PR TITLE
Run migrations on startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ mkdir -p /var/www/html/storage/logs /var/www/html/runtime/logs
 chown -R www-data:www-data /var/www/html/storage/logs /var/www/html/runtime/logs
 
 echo "==> Run migrations"
-php /var/www/html/run migrate
+php /var/www/html/run migrate:run
 
 echo "==> Start php-fpm"
 /usr/local/sbin/php-fpm --nodaemonize &


### PR DESCRIPTION
## Summary
- ensure entrypoint runs pending database migrations at startup

## Testing
- `composer tests` *(fails: phpunit: not found)*
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa4eb050c832d88419db38df9f4db