### PR TITLE
Fix missing database host for Phinx migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # === База данных ===
-# строка подключения к БД
+# строка подключения к БД (при отсутствии будет собрана из переменных ниже)
 DB_DSN="mysql:host=db;dbname=app;charset=utf8mb4"
+DB_HOST="db"
+DB_PORT=3306
+DB_CHARSET="utf8mb4"
 DB_NAME="app"
 # пользователь БД
 DB_USER="app"

--- a/phinx.php
+++ b/phinx.php
@@ -7,6 +7,16 @@ use Dotenv\Dotenv;
 Dotenv::createImmutable(__DIR__)->safeLoad();
 
 $dsn = $_ENV['DB_DSN'] ?? '';
+
+if ($dsn === '') {
+    $host = $_ENV['DB_HOST'] ?? 'localhost';
+    $port = $_ENV['DB_PORT'] ?? '3306';
+    $dbname = $_ENV['DB_NAME'] ?? '';
+    $charset = $_ENV['DB_CHARSET'] ?? 'utf8mb4';
+
+    $dsn = "mysql:host={$host};port={$port};dbname={$dbname};charset={$charset}";
+}
+
 $adapter = explode(':', $dsn, 2)[0] ?: 'mysql';
 
 $db = [


### PR DESCRIPTION
## Summary
- build DSN from DB_HOST, DB_PORT, DB_CHARSET when DB_DSN not provided
- document new fallback variables in `.env.example`

## Testing
- `composer install --no-interaction --no-progress` *(fails: failed to clone https://github.com/php-fig/container.git, CONNECT tunnel failed)*
- `composer cs` *(fails: php-cs-fixer: not found)*
- `composer analyse` *(fails: phpstan: not found)*
- `composer tests` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa68e7994832dafebc4625c625ec6