### PR TITLE
feat: extend init script and add windows deploy

### DIFF
--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -1,0 +1,23 @@
+#!/usr/bin/env pwsh
+param(
+    [string]$Mode = "docker"
+)
+
+switch ($Mode) {
+    "docker" {
+        Write-Host "[Docker] сборка и запуск"
+        docker compose up -d --build
+        docker compose exec app php vendor/bin/phinx migrate | Out-Null
+    }
+    "vps" {
+        Write-Host "[VPS] composer и миграции"
+        composer install --no-dev --optimize-autoloader
+        vendor/bin/phinx migrate -e production | Out-Null
+    }
+    default {
+        Write-Host "использование: .\\deploy.ps1 [docker|vps]"
+        exit 1
+    }
+}
+
+Write-Host "Готово."

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -3,38 +3,151 @@ set -euo pipefail
 
 ENV_FILE=".env"
 
-cp -n .env.example $ENV_FILE 2>/dev/null || true
+# Копируем пример, если .env отсутствует
+cp -n .env.example "$ENV_FILE" 2>/dev/null || true
 
-# ensure default DB_DSN exists
-grep -q '^DB_DSN=' "$ENV_FILE" || echo 'DB_DSN="mysql:host=db;dbname=app;charset=utf8mb4"' >> "$ENV_FILE"
-grep -q '^DB_NAME=' "$ENV_FILE" || echo 'DB_NAME="app"' >> "$ENV_FILE"
+# Добавляет переменную с значением по умолчанию, если её нет
+ensure_var() {
+    local key="$1"
+    local value="$2"
+    grep -q "^${key}=" "$ENV_FILE" || echo "${key}=${value}" >> "$ENV_FILE"
+}
 
-read -rp "Среда приложения APP_ENV (dev/prod) [$(grep -E '^APP_ENV=' $ENV_FILE | cut -d= -f2)]: " APP_ENV || true
-read -rp "Режим отладки APP_DEBUG (true/false) [$(grep -E '^APP_DEBUG=' $ENV_FILE | cut -d= -f2)]: " APP_DEBUG || true
+# Гарантируем наличие всех переменных
+ensure_var "APP_ENV" "dev"
+ensure_var "APP_DEBUG" "true"
+ensure_var "DB_HOST" '"db"'
+ensure_var "DB_PORT" "3306"
+ensure_var "DB_CHARSET" '"utf8mb4"'
+ensure_var "DB_NAME" '"app"'
+ensure_var "DB_USER" '"app"'
+ensure_var "DB_PASS" '"secret"'
+ensure_var "JWT_SECRET" '""'
+ensure_var "CORS_ORIGINS" '"*"'
+ensure_var "RATE_LIMIT_BUCKET" "ip"
+ensure_var "RATE_LIMIT" "60"
+ensure_var "REQUEST_SIZE_LIMIT" "1048576"
+ensure_var "BOT_TOKEN" '""'
+ensure_var "TG_ALLOW_TYPES" '""'
+ensure_var "TG_DENY_TYPES" '""'
+ensure_var "TG_ALLOW_CHATS" '""'
+ensure_var "TG_DENY_CHATS" '""'
+ensure_var "TG_ALLOW_COMMANDS" '""'
+ensure_var "TG_DENY_COMMANDS" '""'
+ensure_var "TG_FILTERS_FROM_REDIS" "false"
+ensure_var "TG_FILTERS_REDIS_PREFIX" '"tg_filters:"'
+ensure_var "TELEMETRY_ENABLED" "false"
+ensure_var "WORKERS_GPT_PROCS" "1"
+ensure_var "WORKERS_TELEGRAM_PROCS" "1"
 
-read -rp "Хост БД [db]: " DB_HOST || true
-DB_HOST=${DB_HOST:-db}
-read -rp "Имя БД [app]: " DB_NAME || true
-DB_NAME=${DB_NAME:-app}
-read -rp "Пользователь БД [app]: " DB_USER || true
-DB_USER=${DB_USER:-app}
-read -rp "Пароль БД [secret]: " DB_PASS || true
-DB_PASS=${DB_PASS:-secret}
+# Читает значение по умолчанию из .env
+get_default() {
+    local key="$1"
+    local val
+    val=$(grep -E "^${key}=" "$ENV_FILE" | cut -d= -f2-)
+    val="${val%\"}"
+    val="${val#\"}"
+    echo "$val"
+}
 
-read -rp "Секрет JWT (оставь пустым для генерации): " JWT_SECRET || true
-if [ -z "${JWT_SECRET:-}" ]; then
+# Считываем значения от пользователя
+read -rp "Среда приложения APP_ENV (dev/prod) [$(get_default APP_ENV)]: " APP_ENV || true
+read -rp "Режим отладки APP_DEBUG (true/false) [$(get_default APP_DEBUG)]: " APP_DEBUG || true
+read -rp "Хост БД [$(get_default DB_HOST)]: " DB_HOST || true
+read -rp "Порт БД [$(get_default DB_PORT)]: " DB_PORT || true
+read -rp "Кодировка БД [$(get_default DB_CHARSET)]: " DB_CHARSET || true
+read -rp "Имя БД [$(get_default DB_NAME)]: " DB_NAME || true
+read -rp "Пользователь БД [$(get_default DB_USER)]: " DB_USER || true
+read -rp "Пароль БД [$(get_default DB_PASS)]: " DB_PASS || true
+read -rp "Секрет JWT (оставь пустым для генерации) [$(get_default JWT_SECRET)]: " JWT_SECRET || true
+if [ -z "${JWT_SECRET:-$(get_default JWT_SECRET)}" ]; then
     JWT_SECRET="$(php -r 'echo bin2hex(random_bytes(32));')"
     echo "JWT_SECRET сгенерирован автоматически."
 fi
+read -rp "Разрешённые CORS origin (через запятую) [$(get_default CORS_ORIGINS)]: " CORS_ORIGINS || true
+read -rp "Тип лимита (ip/user) [$(get_default RATE_LIMIT_BUCKET)]: " RATE_LIMIT_BUCKET || true
+read -rp "Запросов в минуту [$(get_default RATE_LIMIT)]: " RATE_LIMIT || true
+read -rp "Макс размер тела запроса в байтах [$(get_default REQUEST_SIZE_LIMIT)]: " REQUEST_SIZE_LIMIT || true
+read -rp "Токен Telegram-бота [$(get_default BOT_TOKEN)]: " BOT_TOKEN || true
+read -rp "Разрешённые типы обновлений (через запятую) [$(get_default TG_ALLOW_TYPES)]: " TG_ALLOW_TYPES || true
+read -rp "Запрещённые типы обновлений (через запятую) [$(get_default TG_DENY_TYPES)]: " TG_DENY_TYPES || true
+read -rp "Разрешённые чаты (ID через запятую) [$(get_default TG_ALLOW_CHATS)]: " TG_ALLOW_CHATS || true
+read -rp "Запрещённые чаты (ID через запятую) [$(get_default TG_DENY_CHATS)]: " TG_DENY_CHATS || true
+read -rp "Разрешённые команды (через запятую) [$(get_default TG_ALLOW_COMMANDS)]: " TG_ALLOW_COMMANDS || true
+read -rp "Запрещённые команды (через запятую) [$(get_default TG_DENY_COMMANDS)]: " TG_DENY_COMMANDS || true
+read -rp "Брать фильтры из Redis вместо ENV (true/false) [$(get_default TG_FILTERS_FROM_REDIS)]: " TG_FILTERS_FROM_REDIS || true
+read -rp "Префикс ключей Redis для фильтров [$(get_default TG_FILTERS_REDIS_PREFIX)]: " TG_FILTERS_REDIS_PREFIX || true
+read -rp "Включить телеметрию (true/false) [$(get_default TELEMETRY_ENABLED)]: " TELEMETRY_ENABLED || true
+read -rp "Число процессов GPT [$(get_default WORKERS_GPT_PROCS)]: " WORKERS_GPT_PROCS || true
+read -rp "Число процессов Telegram [$(get_default WORKERS_TELEGRAM_PROCS)]: " WORKERS_TELEGRAM_PROCS || true
 
-sed -i "s#^APP_ENV=.*#APP_ENV=${APP_ENV:-dev}#g" $ENV_FILE
-sed -i "s#^APP_DEBUG=.*#APP_DEBUG=${APP_DEBUG:-true}#g" $ENV_FILE
-sed -i "s#^DB_DSN=.*#DB_DSN=\\\"mysql:host=${DB_HOST};dbname=${DB_NAME};charset=utf8mb4\\\"#g" $ENV_FILE
-sed -i "s#^DB_USER=.*#DB_USER=\\\"${DB_USER}\\\"#g" $ENV_FILE
-sed -i "s#^DB_PASS=.*#DB_PASS=\\\"${DB_PASS}\\\"#g" $ENV_FILE
-sed -i "s#^DB_NAME=.*#DB_NAME=\\\"${DB_NAME}\\\"#g" $ENV_FILE
-sed -i "s#^JWT_SECRET=.*#JWT_SECRET=\\\"${JWT_SECRET}\\\"#g" $ENV_FILE
-sed -i "s#^WORKERS_GPT_PROCS=.*#WORKERS_GPT_PROCS=${WORKERS_GPT_PROCS:-1}#g" $ENV_FILE
-sed -i "s#^WORKERS_TELEGRAM_PROCS=.*#WORKERS_TELEGRAM_PROCS=${WORKERS_TELEGRAM_PROCS:-1}#g" $ENV_FILE
+# Подставляем значения по умолчанию, если пользователь ничего не ввёл
+APP_ENV=${APP_ENV:-$(get_default APP_ENV)}
+APP_DEBUG=${APP_DEBUG:-$(get_default APP_DEBUG)}
+DB_HOST=${DB_HOST:-$(get_default DB_HOST)}
+DB_PORT=${DB_PORT:-$(get_default DB_PORT)}
+DB_CHARSET=${DB_CHARSET:-$(get_default DB_CHARSET)}
+DB_NAME=${DB_NAME:-$(get_default DB_NAME)}
+DB_USER=${DB_USER:-$(get_default DB_USER)}
+DB_PASS=${DB_PASS:-$(get_default DB_PASS)}
+CORS_ORIGINS=${CORS_ORIGINS:-$(get_default CORS_ORIGINS)}
+RATE_LIMIT_BUCKET=${RATE_LIMIT_BUCKET:-$(get_default RATE_LIMIT_BUCKET)}
+RATE_LIMIT=${RATE_LIMIT:-$(get_default RATE_LIMIT)}
+REQUEST_SIZE_LIMIT=${REQUEST_SIZE_LIMIT:-$(get_default REQUEST_SIZE_LIMIT)}
+BOT_TOKEN=${BOT_TOKEN:-$(get_default BOT_TOKEN)}
+TG_ALLOW_TYPES=${TG_ALLOW_TYPES:-$(get_default TG_ALLOW_TYPES)}
+TG_DENY_TYPES=${TG_DENY_TYPES:-$(get_default TG_DENY_TYPES)}
+TG_ALLOW_CHATS=${TG_ALLOW_CHATS:-$(get_default TG_ALLOW_CHATS)}
+TG_DENY_CHATS=${TG_DENY_CHATS:-$(get_default TG_DENY_CHATS)}
+TG_ALLOW_COMMANDS=${TG_ALLOW_COMMANDS:-$(get_default TG_ALLOW_COMMANDS)}
+TG_DENY_COMMANDS=${TG_DENY_COMMANDS:-$(get_default TG_DENY_COMMANDS)}
+TG_FILTERS_FROM_REDIS=${TG_FILTERS_FROM_REDIS:-$(get_default TG_FILTERS_FROM_REDIS)}
+TG_FILTERS_REDIS_PREFIX=${TG_FILTERS_REDIS_PREFIX:-$(get_default TG_FILTERS_REDIS_PREFIX)}
+TELEMETRY_ENABLED=${TELEMETRY_ENABLED:-$(get_default TELEMETRY_ENABLED)}
+WORKERS_GPT_PROCS=${WORKERS_GPT_PROCS:-$(get_default WORKERS_GPT_PROCS)}
+WORKERS_TELEGRAM_PROCS=${WORKERS_TELEGRAM_PROCS:-$(get_default WORKERS_TELEGRAM_PROCS)}
 
+# Собираем строку подключения к БД
+DB_DSN="mysql:host=${DB_HOST};port=${DB_PORT};dbname=${DB_NAME};charset=${DB_CHARSET}"
+
+# Записываем в .env
+update_env() {
+    local key="$1"
+    local val="$2"
+    val=$(printf '%s' "$val" | sed 's/[&/]/\\&/g')
+    if [[ "$val" =~ ^[0-9]+$ || "$val" =~ ^(true|false)$ ]]; then
+        sed -i "s#^$key=.*#$key=$val#g" "$ENV_FILE"
+    else
+        sed -i "s#^$key=.*#$key=\"$val\"#g" "$ENV_FILE"
+    fi
+}
+
+update_env APP_ENV "$APP_ENV"
+update_env APP_DEBUG "$APP_DEBUG"
+update_env DB_HOST "$DB_HOST"
+update_env DB_PORT "$DB_PORT"
+update_env DB_CHARSET "$DB_CHARSET"
+update_env DB_NAME "$DB_NAME"
+update_env DB_USER "$DB_USER"
+update_env DB_PASS "$DB_PASS"
+update_env DB_DSN "$DB_DSN"
+update_env JWT_SECRET "$JWT_SECRET"
+update_env CORS_ORIGINS "$CORS_ORIGINS"
+update_env RATE_LIMIT_BUCKET "$RATE_LIMIT_BUCKET"
+update_env RATE_LIMIT "$RATE_LIMIT"
+update_env REQUEST_SIZE_LIMIT "$REQUEST_SIZE_LIMIT"
+update_env BOT_TOKEN "$BOT_TOKEN"
+update_env TG_ALLOW_TYPES "$TG_ALLOW_TYPES"
+update_env TG_DENY_TYPES "$TG_DENY_TYPES"
+update_env TG_ALLOW_CHATS "$TG_ALLOW_CHATS"
+update_env TG_DENY_CHATS "$TG_DENY_CHATS"
+update_env TG_ALLOW_COMMANDS "$TG_ALLOW_COMMANDS"
+update_env TG_DENY_COMMANDS "$TG_DENY_COMMANDS"
+update_env TG_FILTERS_FROM_REDIS "$TG_FILTERS_FROM_REDIS"
+update_env TG_FILTERS_REDIS_PREFIX "$TG_FILTERS_REDIS_PREFIX"
+update_env TELEMETRY_ENABLED "$TELEMETRY_ENABLED"
+update_env WORKERS_GPT_PROCS "$WORKERS_GPT_PROCS"
+update_env WORKERS_TELEGRAM_PROCS "$WORKERS_TELEGRAM_PROCS"
+
+# Готово
 echo "ОК: .env обновлён."


### PR DESCRIPTION
## Summary
- expand init.sh to prompt and persist all .env variables with defaults
- add Windows PowerShell deployment script mirroring deploy.sh

## Testing
- `bash -n scripts/init.sh`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `pwsh -NoLogo -NoProfile -File scripts/deploy.ps1 test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa83f2830832d9ddfa7859633c468