### PR TITLE
Expose database host settings in Phinx configuration

### DIFF
--- a/phinx.php
+++ b/phinx.php
@@ -6,25 +6,22 @@ use Dotenv\Dotenv;
 
 Dotenv::createImmutable(__DIR__)->safeLoad();
 
-$dsn = $_ENV['DB_DSN'] ?? '';
+$host = $_ENV['DB_HOST'] ?? 'localhost';
+$port = $_ENV['DB_PORT'] ?? '3306';
+$dbname = $_ENV['DB_NAME'] ?? '';
+$charset = $_ENV['DB_CHARSET'] ?? 'utf8mb4';
 
-if ($dsn === '') {
-    $host = $_ENV['DB_HOST'] ?? 'localhost';
-    $port = $_ENV['DB_PORT'] ?? '3306';
-    $dbname = $_ENV['DB_NAME'] ?? '';
-    $charset = $_ENV['DB_CHARSET'] ?? 'utf8mb4';
-
-    $dsn = "mysql:host={$host};port={$port};dbname={$dbname};charset={$charset}";
-}
-
+$dsn = $_ENV['DB_DSN'] ?? "mysql:host={$host};port={$port};dbname={$dbname};charset={$charset}";
 $adapter = explode(':', $dsn, 2)[0] ?: 'mysql';
 
 $db = [
     'adapter' => $adapter,
-    'dsn' => $dsn,
-    'name' => $_ENV['DB_NAME'] ?? null,
+    'host' => $host,
+    'port' => $port,
+    'name' => $dbname !== '' ? $dbname : null,
     'user' => $_ENV['DB_USER'] ?? null,
     'pass' => $_ENV['DB_PASS'] ?? null,
+    'charset' => $charset,
 ];
 
 return [


### PR DESCRIPTION
## Summary
- populate Phinx DB config with host, port, and charset from environment
- build DSN from these values and drop redundant `dsn` entry

## Testing
- `composer install --ignore-platform-req=ext-redis` *(fails: CONNECT tunnel failed, response 403)*
- `composer tests` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aaac16ae10832d80b78ebd51dfc2fa