### PR TITLE
Initialize environment and wait for database before migrations

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,22 @@
 #!/bin/sh
 set -e
 
-if [ ! -f /var/www/html/.env ]; then
-  echo "=> Creating .env from .env.example"
-  cp /var/www/html/.env.example /var/www/html/.env
-fi
-
 # Ensure log directories exist and writable
 mkdir -p /var/www/html/storage/logs /var/www/html/runtime/logs
 chown -R www-data:www-data /var/www/html/storage/logs /var/www/html/runtime/logs
+
+echo "==> Initialize application"
+/var/www/html/scripts/init.sh </dev/null
+
+# Read DB connection info from .env
+DB_HOST=$(grep '^DB_HOST=' /var/www/html/.env | cut -d= -f2 | tr -d '"')
+DB_PORT=$(grep '^DB_PORT=' /var/www/html/.env | cut -d= -f2 | tr -d '"')
+
+echo "==> Waiting for database at ${DB_HOST}:${DB_PORT}"
+until nc -z "$DB_HOST" "$DB_PORT"; do
+  echo '... database is unavailable - waiting ...'
+  sleep 2
+done
 
 echo "==> Run migrations"
 php /var/www/html/run migrate:run


### PR DESCRIPTION
## Summary
- Initialize application environment using `scripts/init.sh` before migrations
- Wait for database availability using settings from `.env` before running migrations

## Testing
- `composer install --no-interaction --no-progress` *(fails: PHP extension ext-redis missing)*
- `pecl install redis` *(fails: No releases available)*
- `curl -I https://api.github.com` *(fails: CONNECT tunnel failed, response 403)*
- `composer tests` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaad58d2a0832d9f4778b971b876b1