### PR TITLE
Add dev and prod environments to Phinx config

### DIFF
--- a/phinx.php
+++ b/phinx.php
@@ -31,9 +31,9 @@ return [
     ],
     'environments' => [
         'default_migration_table' => 'phinxlog',
-        'default_environment' => $_ENV['APP_ENV'] ?? 'development',
-        'development' => $db,
-        'production' => $db,
+        'default_environment' => $_ENV['APP_ENV'] ?? 'dev',
+        'dev' => $db,
+        'prod' => $db,
     ],
 ];
 


### PR DESCRIPTION
## Summary
- include `dev` and `prod` environments in Phinx config
- default to `dev` when APP_ENV not set

## Testing
- `composer install --ignore-platform-req=ext-redis` *(fails: CONNECT tunnel failed, response 403)*


------
https://chatgpt.com/codex/tasks/task_e_68aae36550b8832dba5743ed4e9778a7