### PR TITLE
Fix logger default level to avoid invalid empty level

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
+# === Логирование ===
+# канал логирования (по умолчанию app)
+LOG_CHANNEL="app"
+# уровень логирования (DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY)
+LOG_LEVEL="INFO"
+
 # === База данных ===
 # строка подключения к БД (при отсутствии будет собрана из переменных ниже)
 DB_DSN="mysql:host=db;dbname=app;charset=utf8mb4"

--- a/app/Helpers/Logger.php
+++ b/app/Helpers/Logger.php
@@ -67,7 +67,10 @@ class Logger
             try {
                 $config = Config::getInstance();
                 $channel = (string) $config->get('LOG_CHANNEL', 'app');
-                $levelName = (string) $config->get('LOG_LEVEL');
+                $levelName = (string) $config->get('LOG_LEVEL', 'INFO');
+                if ($levelName === '') {
+                    $levelName = 'INFO';
+                }
             } catch (\Throwable) {
                 $channel = 'app';
                 $levelName = 'INFO';


### PR DESCRIPTION
## Summary
- handle empty or missing `LOG_LEVEL` by defaulting to INFO
- document logging channel and level in `.env.example`

## Testing
- `php -l app/Helpers/Logger.php`
- `composer install --no-interaction --ignore-platform-req=ext-redis` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf4a0e0d8832da40154e7c5192ba8