### PR TITLE
Load environment before long polling worker

### DIFF
--- a/workers/longpolling.php
+++ b/workers/longpolling.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Helpers\Logger;
 use App\Helpers\Database;
 use App\Helpers\RedisHelper;
+use Dotenv\Dotenv;
 use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Request;
 use Longman\TelegramBot\Telegram;
@@ -13,7 +14,7 @@ use App\Telegram\UpdateFilter;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-$db = Database::getInstance();
+Dotenv::createImmutable(dirname(__DIR__))->safeLoad();
 
 try {
     $redis = RedisHelper::getInstance();


### PR DESCRIPTION
## Summary
- Use Dotenv to load environment variables in longpolling worker
- Remove premature database initialization

## Testing
- `composer run cs` *(fails: php-cs-fixer not found)*
- `composer run tests` *(fails: phpunit not found)*
- `php -l workers/longpolling.php`

------
https://chatgpt.com/codex/tasks/task_e_68aafd1aa5b0832d9aa4f86ed78af64e