### PR TITLE
feat: add worker handler command

### DIFF
--- a/app/Console/Commands/WorkerHandlerCommand.php
+++ b/app/Console/Commands/WorkerHandlerCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Console\Command;
+use App\Console\Kernel;
+
+final class WorkerHandlerCommand extends Command
+{
+    public string $signature = 'worker:handler';
+    public string $description = 'Handle update payload in background';
+
+    /**
+     * @param array<int, string> $arguments
+     */
+    public function handle(array $arguments, Kernel $kernel): int
+    {
+        $payload = $arguments[0] ?? null;
+        if ($payload === null) {
+            echo 'Missing argument: base64-encoded payload required.' . PHP_EOL;
+            return 1;
+        }
+
+        if (base64_decode($payload, true) === false) {
+            echo 'Invalid argument: payload must be base64-encoded.' . PHP_EOL;
+            return 1;
+        }
+
+        $handler = $_ENV['WORKER_HANDLER_PATH'] ?? dirname(__DIR__, 3) . '/workers/handler.php';
+
+        require $handler;
+
+        return 0;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -17,6 +17,7 @@ class Kernel
         Commands\RefreshTokenPurgeCommand::class,
         Commands\CreateAdminCommand::class,
         Commands\UpdateFilterCommand::class,
+        Commands\WorkerHandlerCommand::class,
     ];
 
     /**

--- a/tests/Unit/WorkerHandlerCommandTest.php
+++ b/tests/Unit/WorkerHandlerCommandTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dotenv {
+    class Dotenv
+    {
+        public static function createImmutable(string $path): self
+        {
+            return new self();
+        }
+
+        public function safeLoad(): void
+        {
+        }
+    }
+}
+
+namespace {
+    spl_autoload_register(
+        static function (string $class): void {
+            if (str_starts_with($class, 'App\\')) {
+                $path = __DIR__ . '/../../' . str_replace('\\', '/', $class) . '.php';
+                if (file_exists($path)) {
+                    require $path;
+                }
+            }
+        }
+    );
+
+    use PHPUnit\Framework\TestCase;
+    use App\Console\Kernel;
+
+    final class WorkerHandlerCommandTest extends TestCase
+    {
+        public function testFailsWithoutArgument(): void
+        {
+            $kernel = new Kernel();
+
+            ob_start();
+            $exitCode = $kernel->handle(['run', 'worker:handler']);
+            $output = ob_get_clean();
+
+            $this->assertSame(1, $exitCode);
+            $this->assertStringContainsString('Missing argument', $output);
+        }
+
+        public function testProcessesPayload(): void
+        {
+            $stub = tempnam(sys_get_temp_dir(), 'handler_stub');
+            file_put_contents(
+                $stub,
+                "<?php\n\$GLOBALS['worker_payload'] = json_decode(base64_decode(\$payload, true), true, 512, JSON_THROW_ON_ERROR);\n"
+            );
+
+            $_ENV['WORKER_HANDLER_PATH'] = $stub;
+            $kernel = new Kernel();
+
+            $update = ['update_id' => 1];
+            $payload = base64_encode(json_encode($update, JSON_THROW_ON_ERROR));
+
+            $exitCode = $kernel->handle(['run', 'worker:handler', $payload]);
+
+            $this->assertSame(0, $exitCode);
+            $this->assertSame($update, $GLOBALS['worker_payload']);
+
+            unset($_ENV['WORKER_HANDLER_PATH'], $GLOBALS['worker_payload']);
+            unlink($stub);
+        }
+    }
+}

--- a/workers/handler.php
+++ b/workers/handler.php
@@ -51,8 +51,12 @@ try {
 }
 
 try {
+    if (empty($payload)) {
+        throw new RuntimeException('Empty payload provided');
+    }
+
     // Получаем данные из аргументов командной строки
-    $updateData = json_decode(base64_decode($argv[1]), true, 512, JSON_THROW_ON_ERROR);
+    $updateData = json_decode(base64_decode($payload, true), true, 512, JSON_THROW_ON_ERROR);
     
     // Передаем данные обновления в экземпляр класса Longman\TelegramBot\Entities\Update
     $update = new Update($updateData, $_ENV['TELEGRAM_BOT_NAME']);


### PR DESCRIPTION
## Summary
- add `worker:handler` console command with base64 payload validation
- expose payload to worker script and fail when empty
- cover command with unit tests

## Testing
- `composer install --ignore-platform-req=ext-redis` *(failed: requires GitHub token)*
- `phpunit tests/Unit/WorkerHandlerCommandTest.php` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab07a88794832d8bb327d96226c473