### PR TITLE
Fix table name for Telegram message updates

### DIFF
--- a/workers/telegram.php
+++ b/workers/telegram.php
@@ -318,7 +318,7 @@ function saveUpdate(int $id, ServerResponse $response, string $queueKey): void
     
     try {
         $stmt = $db->prepare(
-            "UPDATE BOT_messages
+            "UPDATE `telegram_messages`
                SET message_id   = :message_id,
                    status       = :status,
                    response     = :response,


### PR DESCRIPTION
## Summary
- ensure Telegram worker saves message results back to `telegram_messages`

## Testing
- `composer tests` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3e061bb8832da70daef574eb8860