### PR TITLE
Log unknown Telegram commands

### DIFF
--- a/app/Handlers/Telegram/Commands/DefaultCommandHandler.php
+++ b/app/Handlers/Telegram/Commands/DefaultCommandHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Handlers\Telegram\Commands;
 
+use JsonException;
 use Longman\TelegramBot\Entities\Update;
+use Longman\TelegramBot\Request;
 
 class DefaultCommandHandler extends AbstractCommandHandler
 {
@@ -14,6 +16,46 @@ class DefaultCommandHandler extends AbstractCommandHandler
      */
     public function handle(Update $update): void
     {
+        $message = $update->getMessage();
 
+        if ($message === null) {
+            return;
+        }
+
+        $text = trim($message->getText() ?? '');
+        if ($text === '' || !str_starts_with($text, '/')) {
+            return;
+        }
+
+        $parts    = explode(' ', $text);
+        $command  = ltrim(array_shift($parts), '/');
+        $arguments = $parts;
+
+        try {
+            $data = json_encode([
+                'command'   => $command,
+                'arguments' => $arguments,
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+        } catch (JsonException) {
+            $data = '{}';
+        }
+
+        $stmt = $this->db->prepare(
+            'INSERT INTO telegram_updates (update_id, user_id, message_id, type, data, sent_at) '
+            . 'VALUES (:update_id, :user_id, :message_id, :type, :data, :sent_at)'
+        );
+        $stmt->execute([
+            'update_id'  => $update->getUpdateId(),
+            'user_id'    => $message->getFrom()->getId(),
+            'message_id' => $message->getMessageId(),
+            'type'       => 'command',
+            'data'       => $data,
+            'sent_at'    => date('c', $message->getDate()),
+        ]);
+
+        Request::sendMessage([
+            'chat_id' => $message->getChat()->getId(),
+            'text'    => 'Команда обработана',
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- Parse unrecognized Telegram command and arguments from update
- Store command details in `telegram_updates` table
- Reply to user with confirmation message

## Testing
- `composer tests` *(fails: phpunit: not found)*
- `composer install` *(fails: ext-redis missing)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab76c0f800832d83db136d02c1d1de