### PR TITLE
Handle channel posts

### DIFF
--- a/app/Handlers/Telegram/ChannelPosts/DefaultChannelPostHandler.php
+++ b/app/Handlers/Telegram/ChannelPosts/DefaultChannelPostHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Handlers\Telegram\ChannelPosts;
 
+use App\Helpers\Logger;
 use JsonException;
 use Longman\TelegramBot\Entities\Update;
 
@@ -12,10 +13,62 @@ class DefaultChannelPostHandler extends AbstractChannelPostHandler
     public function handle(Update $update): void
     {
         $message = $update->getChannelPost() ?? $update->getEditedChannelPost();
-        
+        if ($message === null) {
+            return;
+        }
+
         $raw = $message->getRawData();
-        $entities = isset($raw['entities']);
-        $forward = isset($raw['forward_from_chat']);
-        $linkPreview = isset($raw['link_preview_options']);
+
+        $text = $message->getText();
+        $caption = $message->getCaption();
+
+        $media = [];
+        foreach (['photo', 'video', 'animation', 'audio', 'voice', 'document', 'video_note', 'sticker'] as $key) {
+            if (isset($raw[$key])) {
+                $media[$key] = $raw[$key];
+            }
+        }
+        $media = $media === [] ? null : $media;
+
+        $entities = $raw['entities'] ?? null;
+        $forwardFromChat = $raw['forward_from_chat'] ?? null;
+        $linkPreview = $raw['link_preview_options'] ?? null;
+        $isAutomaticForward = (bool)($raw['is_automatic_forward'] ?? false);
+
+        try {
+            $stmt = $this->db->prepare(
+                'INSERT INTO telegram_channel_posts (chat_id, message_id, `date`, author_signature, text, caption, entities, media, is_automatic_forward, forward_from_chat, link_preview_options) '
+                . 'VALUES (:chat_id, :message_id, :date, :author_signature, :text, :caption, :entities, :media, :is_automatic_forward, :forward_from_chat, :link_preview_options)'
+            );
+
+            $stmt->execute([
+                'chat_id' => $message->getChat()->getId(),
+                'message_id' => $message->getMessageId(),
+                'date' => date('Y-m-d H:i:s', $message->getDate()),
+                'author_signature' => $message->getAuthorSignature(),
+                'text' => $text,
+                'caption' => $caption,
+                'entities' => $entities ? json_encode($entities, JSON_THROW_ON_ERROR) : null,
+                'media' => $media ? json_encode($media, JSON_THROW_ON_ERROR) : null,
+                'is_automatic_forward' => $isAutomaticForward ? 1 : 0,
+                'forward_from_chat' => $forwardFromChat ? json_encode($forwardFromChat, JSON_THROW_ON_ERROR) : null,
+                'link_preview_options' => $linkPreview ? json_encode($linkPreview, JSON_THROW_ON_ERROR) : null,
+            ]);
+        } catch (JsonException $e) {
+            Logger::error('Failed to save channel post', ['exception' => $e]);
+            return;
+        }
+
+        $content = $text ?? $caption;
+        if ($content !== null) {
+            $this->analyseContent($content);
+        }
+    }
+
+    private function analyseContent(string $content): void
+    {
+        if (stripos($content, 'spam') !== false) {
+            Logger::warning('Channel post contains potential spam');
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extract text, media and metadata from channel posts
- save channel posts in `telegram_channel_posts` with channel and timing info
- add simple content analysis example

## Testing
- `composer cs` *(fails: php-cs-fixer not found)*
- `composer analyse` *(fails: phpstan not found)*
- `composer tests` *(fails: phpunit not found)*
- `php -l app/Handlers/Telegram/ChannelPosts/DefaultChannelPostHandler.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab7c6036f0832db6cff5405287d7b7