### PR TITLE
feat: add chat join requests management

### DIFF
--- a/app/Controllers/Dashboard/ChatJoinRequestsController.php
+++ b/app/Controllers/Dashboard/ChatJoinRequestsController.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Copyright (c) 2025. Vitaliy Kamelin <v.kamelin@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace App\Controllers\Dashboard;
+
+use App\Helpers\Response;
+use App\Helpers\View;
+use Longman\TelegramBot\Request;
+use PDO;
+use Psr\Http\Message\ResponseInterface as Res;
+use Psr\Http\Message\ServerRequestInterface as Req;
+
+/**
+ * Контроллер управления заявками на вступление в чат.
+ */
+final class ChatJoinRequestsController
+{
+    public function __construct(private PDO $pdo) {}
+
+    /**
+     * Отображает таблицу заявок.
+     */
+    public function index(Req $req, Res $res): Res
+    {
+        $data = [
+            'title' => 'Chat Join Requests',
+        ];
+
+        return View::render($res, 'dashboard/join-requests/index.php', $data, 'layouts/main.php');
+    }
+
+    /**
+     * Возвращает данные для DataTables с серверной пагинацией и фильтрами.
+     */
+    public function data(Req $req, Res $res): Res
+    {
+        $p = (array)$req->getParsedBody();
+        $start  = max(0, (int)($p['start'] ?? 0));
+        $length = max(10, (int)($p['length'] ?? 10));
+        $draw   = (int)($p['draw'] ?? 0);
+
+        $conds = [];
+        $params = [];
+
+        if (($p['status'] ?? '') !== '') {
+            $conds[] = 'c.status = :status';
+            $params['status'] = $p['status'];
+        }
+        if (($p['chat_id'] ?? '') !== '') {
+            $conds[] = 'c.chat_id = :chat_id';
+            $params['chat_id'] = $p['chat_id'];
+        }
+        $searchValue = $p['search']['value'] ?? '';
+        if ($searchValue !== '') {
+            $conds[] = '(
+                CAST(c.chat_id AS CHAR) LIKE :search OR
+                CAST(c.user_id AS CHAR) LIKE :search OR
+                tu.username LIKE :search
+            )';
+            $params['search'] = '%' . $searchValue . '%';
+        }
+        $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
+
+        $sql = "SELECT c.chat_id, c.user_id, tu.username, c.bio, c.invite_link, c.requested_at, c.status, c.decided_at, c.decided_by FROM chat_join_requests c LEFT JOIN telegram_users tu ON tu.user_id = c.user_id {$whereSql} ORDER BY c.requested_at DESC LIMIT :limit OFFSET :offset";
+        $stmt = $this->pdo->prepare($sql);
+        foreach ($params as $key => $val) {
+            $stmt->bindValue(':' . $key, $val);
+        }
+        $stmt->bindValue(':limit', $length, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $start, PDO::PARAM_INT);
+        $stmt->execute();
+        $rows = $stmt->fetchAll();
+
+        $countStmt = $this->pdo->prepare("SELECT COUNT(*) FROM chat_join_requests c LEFT JOIN telegram_users tu ON tu.user_id = c.user_id {$whereSql}");
+        foreach ($params as $key => $val) {
+            $countStmt->bindValue(':' . $key, $val);
+        }
+        $countStmt->execute();
+        $recordsFiltered = (int)$countStmt->fetchColumn();
+
+        $recordsTotal = (int)$this->pdo->query('SELECT COUNT(*) FROM chat_join_requests')->fetchColumn();
+
+        return Response::json($res, 200, [
+            'draw' => $draw,
+            'recordsTotal' => $recordsTotal,
+            'recordsFiltered' => $recordsFiltered,
+            'data' => $rows,
+        ]);
+    }
+
+    /**
+     * Отображает карточку заявки.
+     */
+    public function view(Req $req, Res $res, array $args): Res
+    {
+        $chatId = (int)($args['chat_id'] ?? 0);
+        $userId = (int)($args['user_id'] ?? 0);
+        $stmt = $this->pdo->prepare('SELECT c.*, tu.username, tu.first_name, tu.last_name FROM chat_join_requests c LEFT JOIN telegram_users tu ON tu.user_id = c.user_id WHERE c.chat_id = :chat_id AND c.user_id = :user_id');
+        $stmt->execute(['chat_id' => $chatId, 'user_id' => $userId]);
+        $row = $stmt->fetch();
+        if (!$row) {
+            return $res->withStatus(404);
+        }
+
+        $data = [
+            'title' => 'Join Request',
+            'request' => $row,
+        ];
+
+        return View::render($res, 'dashboard/join-requests/view.php', $data, 'layouts/main.php');
+    }
+
+    /**
+     * Одобряет заявку на вступление.
+     */
+    public function approve(Req $req, Res $res, array $args): Res
+    {
+        $chatId = (int)($args['chat_id'] ?? 0);
+        $userId = (int)($args['user_id'] ?? 0);
+        Request::approveChatJoinRequest(['chat_id' => $chatId, 'user_id' => $userId]);
+        $stmt = $this->pdo->prepare('UPDATE chat_join_requests SET status = :status, decided_at = CURRENT_TIMESTAMP, decided_by = :decided_by WHERE chat_id = :chat_id AND user_id = :user_id');
+        $stmt->execute([
+            'status' => 'approved',
+            'decided_by' => $_SESSION['user_id'] ?? null,
+            'chat_id' => $chatId,
+            'user_id' => $userId,
+        ]);
+
+        return $res->withHeader('Location', '/dashboard/join-requests')->withStatus(302);
+    }
+
+    /**
+     * Отклоняет заявку на вступление.
+     */
+    public function decline(Req $req, Res $res, array $args): Res
+    {
+        $chatId = (int)($args['chat_id'] ?? 0);
+        $userId = (int)($args['user_id'] ?? 0);
+        Request::declineChatJoinRequest(['chat_id' => $chatId, 'user_id' => $userId]);
+        $stmt = $this->pdo->prepare('UPDATE chat_join_requests SET status = :status, decided_at = CURRENT_TIMESTAMP, decided_by = :decided_by WHERE chat_id = :chat_id AND user_id = :user_id');
+        $stmt->execute([
+            'status' => 'declined',
+            'decided_by' => $_SESSION['user_id'] ?? null,
+            'chat_id' => $chatId,
+            'user_id' => $userId,
+        ]);
+
+        return $res->withHeader('Location', '/dashboard/join-requests')->withStatus(302);
+    }
+}

--- a/public/assets/js/datatable.join-requests.js
+++ b/public/assets/js/datatable.join-requests.js
@@ -1,0 +1,34 @@
+$(document).ready(function() {
+  const params = new URLSearchParams(window.location.search);
+  const csrfToken = window.csrfToken;
+
+  createDatatable('#joinRequestsTable', '/dashboard/join-requests/data', [
+    { data: 'chat_id' },
+    { data: 'user_id' },
+    { data: 'username' },
+    { data: 'bio' },
+    { data: 'invite_link' },
+    { data: 'requested_at' },
+    { data: 'status' },
+    { data: 'decided_at' },
+    { data: 'decided_by' },
+    {
+      data: null,
+      render: function(data, type, row) {
+        return '<a href="/dashboard/join-requests/' + row.chat_id + '/' + row.user_id + '" class="btn btn-sm btn-outline-secondary me-1">View</a>'
+          + '<form method="post" action="/dashboard/join-requests/' + row.chat_id + '/' + row.user_id + '/approve" class="d-inline">'
+          + '<input type="hidden" name="_csrf_token" value="' + csrfToken + '">' + '<button type="submit" class="btn btn-sm btn-outline-success">Approve</button>' + '</form>'
+          + '<form method="post" action="/dashboard/join-requests/' + row.chat_id + '/' + row.user_id + '/decline" class="d-inline ms-1">'
+          + '<input type="hidden" name="_csrf_token" value="' + csrfToken + '">' + '<button type="submit" class="btn btn-sm btn-outline-danger">Decline</button>' + '</form>';
+      },
+      orderable: false,
+      searchable: false
+    }
+  ], function(d) {
+    ['status','chat_id'].forEach(function(key) {
+      if (params.has(key)) {
+        d[key] = params.get(key);
+      }
+    });
+  });
+});

--- a/public/index.php
+++ b/public/index.php
@@ -57,6 +57,11 @@ $app->group('/dashboard', function (\Slim\Routing\RouteCollectorProxy $g) use ($
         $auth->get('/tg-users', [\App\Controllers\Dashboard\TgUsersController::class, 'index']);
         $auth->post('/tg-users/data', [\App\Controllers\Dashboard\TgUsersController::class, 'data']);
         $auth->get('/tg-users/{id}', [\App\Controllers\Dashboard\TgUsersController::class, 'view']);
+        $auth->get('/join-requests', [\App\Controllers\Dashboard\ChatJoinRequestsController::class, 'index']);
+        $auth->post('/join-requests/data', [\App\Controllers\Dashboard\ChatJoinRequestsController::class, 'data']);
+        $auth->get('/join-requests/{chat_id}/{user_id}', [\App\Controllers\Dashboard\ChatJoinRequestsController::class, 'view']);
+        $auth->post('/join-requests/{chat_id}/{user_id}/approve', [\App\Controllers\Dashboard\ChatJoinRequestsController::class, 'approve']);
+        $auth->post('/join-requests/{chat_id}/{user_id}/decline', [\App\Controllers\Dashboard\ChatJoinRequestsController::class, 'decline']);
         $auth->get('/users', [\App\Controllers\Dashboard\PanelUsersController::class, 'index']);
         $auth->post('/users/data', [\App\Controllers\Dashboard\PanelUsersController::class, 'data']);
         $auth->get('/users/create', [\App\Controllers\Dashboard\PanelUsersController::class, 'create']);

--- a/templates/dashboard/join-requests/index.php
+++ b/templates/dashboard/join-requests/index.php
@@ -1,0 +1,70 @@
+<!-- DataTables CSS -->
+<link rel="stylesheet" href="https://cdn.datatables.net/1.10.25/css/dataTables.bootstrap5.min.css">
+
+<!-- Buttons CSS -->
+<link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.3.3/css/buttons.bootstrap5.min.css">
+
+<h1>Chat Join Requests</h1>
+
+<form method="get" class="row g-2 mb-3">
+    <div class="col-auto">
+        <select name="status" class="form-select">
+            <option value="">status</option>
+            <option value="pending" <?= isset($_GET['status']) && $_GET['status'] === 'pending' ? 'selected' : '' ?>>pending</option>
+            <option value="approved" <?= isset($_GET['status']) && $_GET['status'] === 'approved' ? 'selected' : '' ?>>approved</option>
+            <option value="declined" <?= isset($_GET['status']) && $_GET['status'] === 'declined' ? 'selected' : '' ?>>declined</option>
+        </select>
+    </div>
+    <div class="col-auto">
+        <input type="text" name="chat_id" value="<?= htmlspecialchars($_GET['chat_id'] ?? '') ?>" class="form-control" placeholder="chat_id">
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-primary">Filter</button>
+    </div>
+</form>
+
+<table id="joinRequestsTable" class="table table-center table-striped table-hover">
+    <thead>
+    <tr>
+        <th>Chat ID</th>
+        <th>User ID</th>
+        <th>Username</th>
+        <th>Bio</th>
+        <th>Invite Link</th>
+        <th>Requested At</th>
+        <th>Status</th>
+        <th>Decided At</th>
+        <th>Decided By</th>
+        <th>Actions</th>
+    </tr>
+    </thead>
+    <tbody></tbody>
+    <tfoot>
+    <tr>
+        <th>Chat ID</th>
+        <th>User ID</th>
+        <th>Username</th>
+        <th>Bio</th>
+        <th>Invite Link</th>
+        <th>Requested At</th>
+        <th>Status</th>
+        <th>Decided At</th>
+        <th>Decided By</th>
+        <th>Actions</th>
+    </tr>
+    </tfoot>
+</table>
+
+<!-- jQuery и DataTables JS -->
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.datatables.net/1.10.25/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/1.10.25/js/dataTables.bootstrap5.min.js"></script>
+
+<!-- Buttons core и HTML5-экспорт -->
+<script src="https://cdn.datatables.net/buttons/2.3.3/js/dataTables.buttons.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.3.3/js/buttons.html5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.3.3/js/buttons.bootstrap5.min.js"></script>
+
+<script src="<?= url('/assets/js/datatable.common.js') ?>"></script>
+<script src="<?= url('/assets/js/datatable.join-requests.js') ?>"></script>

--- a/templates/dashboard/join-requests/view.php
+++ b/templates/dashboard/join-requests/view.php
@@ -1,0 +1,43 @@
+<?php
+/** @var array $request */
+/** @var string $csrfToken */
+?>
+<h1>Join Request <?= htmlspecialchars((string)$request['user_id']) ?></h1>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <dl class="row mb-0">
+            <dt class="col-sm-3">Chat ID</dt>
+            <dd class="col-sm-9"><?= htmlspecialchars((string)$request['chat_id']) ?></dd>
+            <dt class="col-sm-3">User ID</dt>
+            <dd class="col-sm-9"><?= htmlspecialchars((string)$request['user_id']) ?></dd>
+            <dt class="col-sm-3">Username</dt>
+            <dd class="col-sm-9"><?= htmlspecialchars((string)$request['username']) ?></dd>
+            <dt class="col-sm-3">First name</dt>
+            <dd class="col-sm-9"><?= htmlspecialchars((string)$request['first_name']) ?></dd>
+            <dt class="col-sm-3">Last name</dt>
+            <dd class="col-sm-9"><?= htmlspecialchars((string)$request['last_name']) ?></dd>
+            <dt class="col-sm-3">Bio</dt>
+            <dd class="col-sm-9"><pre class="mb-0"><?= htmlspecialchars((string)$request['bio']) ?></pre></dd>
+            <dt class="col-sm-3">Invite Link</dt>
+            <dd class="col-sm-9"><pre class="mb-0"><?= htmlspecialchars((string)$request['invite_link']) ?></pre></dd>
+            <dt class="col-sm-3">Requested at</dt>
+            <dd class="col-sm-9"><?= htmlspecialchars((string)$request['requested_at']) ?></dd>
+            <dt class="col-sm-3">Status</dt>
+            <dd class="col-sm-9"><?= htmlspecialchars((string)$request['status']) ?></dd>
+            <dt class="col-sm-3">Decided at</dt>
+            <dd class="col-sm-9"><?= htmlspecialchars((string)$request['decided_at']) ?></dd>
+            <dt class="col-sm-3">Decided by</dt>
+            <dd class="col-sm-9"><?= htmlspecialchars((string)$request['decided_by']) ?></dd>
+        </dl>
+    </div>
+</div>
+
+<form method="post" action="/dashboard/join-requests/<?= urlencode((string)$request['chat_id']) ?>/<?= urlencode((string)$request['user_id']) ?>/approve" class="d-inline">
+    <input type="hidden" name="<?= env('CSRF_TOKEN_NAME', '_csrf_token') ?>" value="<?= $csrfToken ?>">
+    <button type="submit" class="btn btn-success">Approve</button>
+</form>
+<form method="post" action="/dashboard/join-requests/<?= urlencode((string)$request['chat_id']) ?>/<?= urlencode((string)$request['user_id']) ?>/decline" class="d-inline ms-2">
+    <input type="hidden" name="<?= env('CSRF_TOKEN_NAME', '_csrf_token') ?>" value="<?= $csrfToken ?>">
+    <button type="submit" class="btn btn-danger">Decline</button>
+</form>

--- a/templates/menu.php
+++ b/templates/menu.php
@@ -27,6 +27,11 @@ $menu = [
         'icon'  => 'bi bi-people-fill',
     ],
     [
+        'url'   => '/dashboard/join-requests',
+        'title' => 'Join Requests',
+        'icon'  => 'bi bi-person-plus',
+    ],
+    [
         'url'   => '/dashboard/sessions',
         'title' => 'Sessions',
         'icon'  => 'bi bi-clock-history',

--- a/tests/Unit/ChatJoinRequestsControllerTest.php
+++ b/tests/Unit/ChatJoinRequestsControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Longman\TelegramBot {
+    class Request
+    {
+        public static array $calls = [];
+        public static function approveChatJoinRequest(array $params): object
+        {
+            self::$calls[] = ['approve', $params];
+            return (object)['ok' => true];
+        }
+        public static function declineChatJoinRequest(array $params): object
+        {
+            self::$calls[] = ['decline', $params];
+            return (object)['ok' => true];
+        }
+    }
+}
+
+namespace Tests\Unit {
+    use App\Controllers\Dashboard\ChatJoinRequestsController;
+    use PDO;
+    use PHPUnit\Framework\TestCase;
+    use Slim\Psr7\Factory\ServerRequestFactory;
+    use Slim\Psr7\Response;
+
+    final class ChatJoinRequestsControllerTest extends TestCase
+    {
+        private PDO $pdo;
+        private ChatJoinRequestsController $controller;
+
+        protected function setUp(): void
+        {
+            $this->pdo = new PDO('sqlite::memory:');
+            $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+            $this->pdo->exec('CREATE TABLE chat_join_requests (chat_id INTEGER, user_id INTEGER, bio TEXT, invite_link TEXT, requested_at TEXT, status TEXT, decided_at TEXT, decided_by INTEGER, PRIMARY KEY(chat_id, user_id))');
+            $this->pdo->exec('CREATE TABLE telegram_users (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, username TEXT, first_name TEXT, last_name TEXT)');
+            $this->pdo->exec("INSERT INTO telegram_users (user_id, username, first_name, last_name) VALUES (1, 'john', 'John', 'Doe')");
+            $this->pdo->exec("INSERT INTO chat_join_requests (chat_id, user_id, bio, invite_link, requested_at, status) VALUES (100, 1, 'bio', NULL, '2024-01-01 00:00:00', 'pending')");
+            $this->controller = new ChatJoinRequestsController($this->pdo);
+            $_SESSION = ['user_id' => 99];
+        }
+
+        public function testDataReturnsJson(): void
+        {
+            $factory = new ServerRequestFactory();
+            $req = $factory->createServerRequest('POST', '/');
+            $req = $req->withParsedBody(['draw' => 1, 'start' => 0, 'length' => 10]);
+            $res = new Response();
+            $res = $this->controller->data($req, $res);
+            $payload = json_decode((string)$res->getBody(), true);
+            $this->assertSame(1, $payload['draw']);
+            $this->assertSame(1, $payload['recordsTotal']);
+            $this->assertSame('john', $payload['data'][0]['username']);
+        }
+
+        public function testApproveAndDeclineUpdateStatus(): void
+        {
+            $factory = new ServerRequestFactory();
+            $req = $factory->createServerRequest('POST', '/');
+            $res = new Response();
+            $this->controller->approve($req, $res, ['chat_id' => 100, 'user_id' => 1]);
+            $row = $this->pdo->query('SELECT status, decided_by FROM chat_join_requests WHERE chat_id = 100 AND user_id = 1')->fetch();
+            $this->assertSame('approved', $row['status']);
+            $this->assertSame(99, (int)$row['decided_by']);
+
+            $this->pdo->exec("INSERT INTO chat_join_requests (chat_id, user_id, bio, invite_link, requested_at, status) VALUES (100, 2, '', NULL, '2024-01-01 00:00:00', 'pending')");
+            $req2 = $factory->createServerRequest('POST', '/');
+            $res2 = new Response();
+            $this->controller->decline($req2, $res2, ['chat_id' => 100, 'user_id' => 2]);
+            $row2 = $this->pdo->query('SELECT status FROM chat_join_requests WHERE chat_id = 100 AND user_id = 2')->fetch();
+            $this->assertSame('declined', $row2['status']);
+
+            $this->assertSame([
+                ['approve', ['chat_id' => 100, 'user_id' => 1]],
+                ['decline', ['chat_id' => 100, 'user_id' => 2]],
+            ], \Longman\TelegramBot\Request::$calls);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ChatJoinRequestsController with DataTables and approve/decline actions
- register dashboard routes, menu entry and templates for join requests
- provide DataTable JS and unit tests for join request workflow

## Testing
- `composer install --ignore-platform-req=ext-redis` *(fails: GitHub authentication required)*
- `composer tests` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab850ac470832da2f7d6c95d3b6582