### PR TITLE
Add index for chat join requests status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Добавлены инструкции по запуску health-эндпойнта, `TelegramInitDataMiddleware` и мини-приложению Telegram.
 - Описана переменная `BOT_TOKEN`, сценарии проверки `initData` и примеры запросов.
 - Страница `/dashboard/system` с env-переменными и командами воркеров.
+- Миграция: добавлен индекс `idx_chat_join_requests_status` на `chat_join_requests.status`.
 
 ### Changed
 - Заменены упоминания `/admin` на `/dashboard` в документации.

--- a/database/migrations/20250902011800_add_idx_chat_join_requests_status.php
+++ b/database/migrations/20250902011800_add_idx_chat_join_requests_status.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddIdxChatJoinRequestsStatus extends AbstractMigration
+{
+    public function up(): void
+    {
+        $exists = $this->fetchRow("SHOW INDEX FROM `chat_join_requests` WHERE Key_name = 'idx_chat_join_requests_status'");
+        if (! $exists) {
+            $this->execute("CREATE INDEX `idx_chat_join_requests_status` ON `chat_join_requests` (`status`);");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add phinx migration to index `chat_join_requests.status`
- document the new index in the changelog

## Testing
- `composer install --ignore-platform-req=ext-redis --no-interaction` *(fails: Proxy CONNECT aborted due to timeout)*
- `composer tests` *(fails: phpunit: not found)*
- `sqlite3 /tmp/chat_join_requests_empty.sqlite "CREATE TABLE chat_join_requests (chat_id INTEGER, user_id INTEGER, status TEXT); CREATE INDEX idx_chat_join_requests_status ON chat_join_requests(status); PRAGMA index_list('chat_join_requests');"`
- `sqlite3 /tmp/chat_join_requests_existing.sqlite "CREATE TABLE chat_join_requests (chat_id INTEGER, user_id INTEGER, status TEXT); INSERT INTO chat_join_requests VALUES (1, 100, 'pending'); CREATE INDEX idx_chat_join_requests_status ON chat_join_requests(status); SELECT status FROM chat_join_requests WHERE chat_id=1; PRAGMA index_list('chat_join_requests');"`


------
https://chatgpt.com/codex/tasks/task_e_68ab8915f3e4832d88aec1447a5eb1ad