### PR TITLE
Persist message reaction counts

### DIFF
--- a/app/Handlers/Telegram/MessageReactionCounts/DefaultMessageReactionCountHandler.php
+++ b/app/Handlers/Telegram/MessageReactionCounts/DefaultMessageReactionCountHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Handlers\Telegram\MessageReactionCounts;
 
+use App\Helpers\Logger;
 use App\Telegram\UpdateHelper;
 use JsonException;
 use Longman\TelegramBot\Entities\Update;
@@ -16,7 +17,46 @@ class DefaultMessageReactionCountHandler extends AbstractMessageReactionCountHan
         if ($reaction === null) {
             return;
         }
-        
+
+        $chatId = isset($reaction['chat']['id']) ? (int)$reaction['chat']['id'] : null;
+        $messageId = isset($reaction['message_id']) ? (int)$reaction['message_id'] : null;
         $reactions = $reaction['reactions'] ?? [];
+
+        if ($chatId === null || $messageId === null) {
+            return;
+        }
+
+        $agg = [];
+        foreach ($reactions as $r) {
+            $emoji = $r['type']['emoji'] ?? ($r['type']['custom_emoji_id'] ?? null);
+            $count = $r['count'] ?? null;
+            if ($emoji !== null && $count !== null) {
+                $agg[(string)$emoji] = (int)$count;
+            }
+        }
+
+        try {
+            $stmt = $this->db->prepare(
+                'INSERT INTO message_reactions_agg (chat_id, message_id, agg, updated_at) '
+                . 'VALUES (:chat_id, :message_id, :agg, NOW()) '
+                . 'ON DUPLICATE KEY UPDATE agg = VALUES(agg), updated_at = VALUES(updated_at)'
+            );
+            $stmt->execute([
+                'chat_id' => $chatId,
+                'message_id' => $messageId,
+                'agg' => json_encode($agg, JSON_THROW_ON_ERROR),
+            ]);
+        } catch (JsonException $e) {
+            Logger::error('Failed to save aggregated message reactions', ['exception' => $e]);
+            return;
+        }
+
+        // Example: simple analysis of reactions — determine the leading emoji
+        if (!empty($agg)) {
+            arsort($agg);
+            $leaderEmoji = array_key_first($agg);
+            $leaderCount = $agg[$leaderEmoji];
+            Logger::info('Top reaction emoji', ['emoji' => $leaderEmoji, 'count' => $leaderCount]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- persist aggregated message reaction counts in `message_reactions_agg`
- log the leading emoji as a simple reaction analysis

## Testing
- `php -l app/Handlers/Telegram/MessageReactionCounts/DefaultMessageReactionCountHandler.php`
- `vendor/bin/phpunit` *(fails: vendor/bin/phpunit not found; composer install blocked by missing ext-redis and GitHub 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab92959404832daf7aa1289ba1ee96