### PR TITLE
Handle pre-checkout query storage and notification

### DIFF
--- a/app/Handlers/Telegram/PreCheckoutQueries/DefaultPreCheckoutQueryHandler.php
+++ b/app/Handlers/Telegram/PreCheckoutQueries/DefaultPreCheckoutQueryHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Handlers\Telegram\PreCheckoutQueries;
 
+use App\Helpers\Push;
 use JsonException;
 use Longman\TelegramBot\Entities\Update;
 
@@ -12,8 +13,38 @@ class DefaultPreCheckoutQueryHandler extends AbstractPreCheckoutQueryHandler
     public function handle(Update $update): void
     {
         $preCheckoutQuery = $update->getPreCheckoutQuery();
+        if ($preCheckoutQuery === null) {
+            return;
+        }
+
         $orderInfo = $preCheckoutQuery->getOrderInfo();
 
+        try {
+            $orderInfoJson = $orderInfo !== null
+                ? json_encode($orderInfo->getRawData(), JSON_THROW_ON_ERROR)
+                : null;
+        } catch (JsonException $e) {
+            $orderInfoJson = null;
+        }
+
+        $stmt = $this->db->prepare(
+            'INSERT INTO precheckout_queries '
+            . '(pre_checkout_query_id, from_user_id, currency, total_amount, invoice_payload, shipping_option_id, order_info, received_at) '
+            . 'VALUES (:pre_checkout_query_id, :from_user_id, :currency, :total_amount, :invoice_payload, :shipping_option_id, :order_info, NOW())'
+        );
+
+        $stmt->execute([
+            'pre_checkout_query_id' => $preCheckoutQuery->getId(),
+            'from_user_id' => $preCheckoutQuery->getFrom()->getId(),
+            'currency' => $preCheckoutQuery->getCurrency(),
+            'total_amount' => $preCheckoutQuery->getTotalAmount(),
+            'invoice_payload' => $preCheckoutQuery->getInvoicePayload(),
+            'shipping_option_id' => $preCheckoutQuery->getShippingOptionId(),
+            'order_info' => $orderInfoJson,
+        ]);
+
         $this->answerPreCheckoutQuery($preCheckoutQuery->getId(), true);
+
+        Push::text((int) $preCheckoutQuery->getFrom()->getId(), 'Ваш заказ принят.');
     }
 }


### PR DESCRIPTION
## Summary
- Store pre-checkout query, user, and order data in `precheckout_queries`
- Notify user that order is accepted after answering the query

## Testing
- `composer tests` *(fails: phpunit: not found)*
- `composer install` *(fails: ext-redis extension missing)*
- `composer install --ignore-platform-req=ext-redis` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9465a50c832d9baf2b7e57582ffb