### PR TITLE
feat: add pre-checkout dashboard listing

### DIFF
--- a/app/Controllers/Dashboard/PreCheckoutController.php
+++ b/app/Controllers/Dashboard/PreCheckoutController.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Copyright (c) 2025. Vitaliy Kamelin <v.kamelin@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace App\Controllers\Dashboard;
+
+use App\Helpers\Response;
+use App\Helpers\View;
+use PDO;
+use Psr\Http\Message\ResponseInterface as Res;
+use Psr\Http\Message\ServerRequestInterface as Req;
+
+/**
+ * Контроллер для просмотра pre-checkout запросов.
+ */
+final class PreCheckoutController
+{
+    public function __construct(private PDO $pdo) {}
+
+    /**
+     * Отображает таблицу pre-checkout запросов.
+     */
+    public function index(Req $req, Res $res): Res
+    {
+        $data = [
+            'title' => 'Pre-checkout',
+        ];
+
+        return View::render($res, 'dashboard/pre-checkout/index.php', $data, 'layouts/main.php');
+    }
+
+    /**
+     * Возвращает данные для DataTables.
+     */
+    public function data(Req $req, Res $res): Res
+    {
+        $p = (array)$req->getParsedBody();
+        $start  = max(0, (int)($p['start'] ?? 0));
+        $length = max(10, (int)($p['length'] ?? 10));
+        $draw   = (int)($p['draw'] ?? 0);
+
+        $conds = [];
+        $params = [];
+
+        if (($p['from_user_id'] ?? '') !== '') {
+            $conds[] = 'from_user_id = :from_user_id';
+            $params['from_user_id'] = $p['from_user_id'];
+        }
+        if (($p['currency'] ?? '') !== '') {
+            $conds[] = 'currency = :currency';
+            $params['currency'] = $p['currency'];
+        }
+        if (($p['received_from'] ?? '') !== '') {
+            $conds[] = 'received_at >= :received_from';
+            $params['received_from'] = $p['received_from'];
+        }
+        if (($p['received_to'] ?? '') !== '') {
+            $conds[] = 'received_at <= :received_to';
+            $params['received_to'] = $p['received_to'];
+        }
+        $searchValue = $p['search']['value'] ?? '';
+        if ($searchValue !== '') {
+            $conds[] = '(
+                pre_checkout_query_id LIKE :search OR
+                CAST(from_user_id AS CHAR) LIKE :search OR
+                currency LIKE :search OR
+                CAST(total_amount AS CHAR) LIKE :search OR
+                invoice_payload LIKE :search OR
+                shipping_option_id LIKE :search OR
+                order_info LIKE :search
+            )';
+            $params['search'] = '%' . $searchValue . '%';
+        }
+        $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
+
+        $sql = "SELECT pre_checkout_query_id, from_user_id, currency, total_amount, shipping_option_id, received_at FROM tg_pre_checkout {$whereSql} ORDER BY received_at DESC LIMIT :limit OFFSET :offset";
+        $stmt = $this->pdo->prepare($sql);
+        foreach ($params as $key => $val) {
+            $stmt->bindValue(':' . $key, $val);
+        }
+        $stmt->bindValue(':limit', $length, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $start, PDO::PARAM_INT);
+        $stmt->execute();
+        $rows = $stmt->fetchAll();
+
+        $countStmt = $this->pdo->prepare("SELECT COUNT(*) FROM tg_pre_checkout {$whereSql}");
+        foreach ($params as $key => $val) {
+            $countStmt->bindValue(':' . $key, $val);
+        }
+        $countStmt->execute();
+        $recordsFiltered = (int)$countStmt->fetchColumn();
+
+        $recordsTotal = (int)$this->pdo->query('SELECT COUNT(*) FROM tg_pre_checkout')->fetchColumn();
+
+        return Response::json($res, 200, [
+            'draw' => $draw,
+            'recordsTotal' => $recordsTotal,
+            'recordsFiltered' => $recordsFiltered,
+            'data' => $rows,
+        ]);
+    }
+}

--- a/public/assets/js/datatable.pre-checkout.js
+++ b/public/assets/js/datatable.pre-checkout.js
@@ -1,0 +1,10 @@
+$(document).ready(function() {
+  createDatatable('#preCheckoutTable', '/dashboard/pre-checkout/data', [
+    { data: 'pre_checkout_query_id' },
+    { data: 'from_user_id' },
+    { data: 'currency' },
+    { data: 'total_amount' },
+    { data: 'shipping_option_id' },
+    { data: 'received_at' }
+  ]);
+});

--- a/public/index.php
+++ b/public/index.php
@@ -46,6 +46,8 @@ $app->group('/dashboard', function (\Slim\Routing\RouteCollectorProxy $g) use ($
         $auth->post('/messages/data', [\App\Controllers\Dashboard\MessagesController::class, 'data']);
         $auth->post('/messages/{id}/resend', [\App\Controllers\Dashboard\MessagesController::class, 'resend']);
         $auth->get('/messages/{id}/response', [\App\Controllers\Dashboard\MessagesController::class, 'download']);
+        $auth->get('/pre-checkout', [\App\Controllers\Dashboard\PreCheckoutController::class, 'index']);
+        $auth->post('/pre-checkout/data', [\App\Controllers\Dashboard\PreCheckoutController::class, 'data']);
         $auth->get('/updates', [\App\Controllers\Dashboard\UpdatesController::class, 'index']);
         $auth->post('/updates/data', [\App\Controllers\Dashboard\UpdatesController::class, 'data']);
         $auth->get('/updates/{id}', [\App\Controllers\Dashboard\UpdatesController::class, 'show']);

--- a/templates/dashboard/pre-checkout/index.php
+++ b/templates/dashboard/pre-checkout/index.php
@@ -1,0 +1,45 @@
+<!-- DataTables CSS -->
+<link rel="stylesheet" href="https://cdn.datatables.net/1.10.25/css/dataTables.bootstrap5.min.css">
+
+<!-- Buttons CSS -->
+<link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.3.3/css/buttons.bootstrap5.min.css">
+
+<h1>Pre-checkout</h1>
+
+<table id="preCheckoutTable" class="table table-center table-striped table-hover">
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>From User ID</th>
+        <th>Currency</th>
+        <th>Total Amount</th>
+        <th>Shipping Option ID</th>
+        <th>Received At</th>
+    </tr>
+    </thead>
+    <tbody></tbody>
+    <tfoot>
+    <tr>
+        <th>ID</th>
+        <th>From User ID</th>
+        <th>Currency</th>
+        <th>Total Amount</th>
+        <th>Shipping Option ID</th>
+        <th>Received At</th>
+    </tr>
+    </tfoot>
+</table>
+
+<!-- jQuery и DataTables JS -->
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.datatables.net/1.10.25/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/1.10.25/js/dataTables.bootstrap5.min.js"></script>
+
+<!-- Buttons core и HTML5-экспорт -->
+<script src="https://cdn.datatables.net/buttons/2.3.3/js/dataTables.buttons.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.3.3/js/buttons.html5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.3.3/js/buttons.bootstrap5.min.js"></script>
+
+<script src="<?= url('/assets/js/datatable.common.js') ?>"></script>
+<script src="<?= url('/assets/js/datatable.pre-checkout.js') ?>"></script>

--- a/templates/menu.php
+++ b/templates/menu.php
@@ -12,6 +12,11 @@ $menu = [
         'icon'  => 'bi bi-chat-right-text',
     ],
     [
+        'url'   => '/dashboard/pre-checkout',
+        'title' => 'Pre-checkout',
+        'icon'  => 'bi bi-receipt',
+    ],
+    [
         'url'   => '/dashboard/scheduled',
         'title' => 'Scheduled',
         'icon'  => 'bi bi-clock',

--- a/tests/Unit/PreCheckoutControllerTest.php
+++ b/tests/Unit/PreCheckoutControllerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Controllers\Dashboard\PreCheckoutController;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Response;
+
+final class PreCheckoutControllerTest extends TestCase
+{
+    private PDO $pdo;
+    private PreCheckoutController $controller;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('CREATE TABLE tg_pre_checkout (pre_checkout_query_id TEXT PRIMARY KEY, from_user_id INTEGER, currency TEXT, total_amount INTEGER, invoice_payload TEXT, shipping_option_id TEXT, order_info TEXT, received_at TEXT)');
+        $this->pdo->exec("INSERT INTO tg_pre_checkout (pre_checkout_query_id, from_user_id, currency, total_amount, invoice_payload, shipping_option_id, order_info, received_at) VALUES ('abc', 1, 'USD', 1000, 'payload', 'ship1', '{}', '2024-01-01 00:00:00')");
+        $this->controller = new PreCheckoutController($this->pdo);
+    }
+
+    public function testDataReturnsJson(): void
+    {
+        $factory = new ServerRequestFactory();
+        $req = $factory->createServerRequest('POST', '/');
+        $req = $req->withParsedBody(['draw' => 1, 'start' => 0, 'length' => 10]);
+        $res = new Response();
+        $res = $this->controller->data($req, $res);
+        $payload = json_decode((string)$res->getBody(), true);
+        $this->assertSame(1, $payload['recordsTotal']);
+        $this->assertSame('abc', $payload['data'][0]['pre_checkout_query_id']);
+        $this->assertSame(1000, (int)$payload['data'][0]['total_amount']);
+    }
+}


### PR DESCRIPTION
## Summary
- add PreCheckoutController with server-side pagination
- show pre-checkout records in dashboard and datatable
- register routes, menu item and unit test

## Testing
- `composer tests` *(fails: phpunit: not found)*
- `composer install --ignore-platform-req=ext-redis --no-interaction` *(fails: missing PHP extension/ext-redis)*

------
https://chatgpt.com/codex/tasks/task_e_68abedb1482c832d98ab5ff1809684fe