### PR TITLE
Add shipping queries dashboard

### DIFF
--- a/app/Controllers/Dashboard/ShippingQueriesController.php
+++ b/app/Controllers/Dashboard/ShippingQueriesController.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Copyright (c) 2025. Vitaliy Kamelin <v.kamelin@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace App\Controllers\Dashboard;
+
+use App\Helpers\Response;
+use App\Helpers\View;
+use PDO;
+use Psr\Http\Message\ResponseInterface as Res;
+use Psr\Http\Message\ServerRequestInterface as Req;
+
+/**
+ * Контроллер для просмотра запросов на доставку.
+ */
+final class ShippingQueriesController
+{
+    public function __construct(private PDO $pdo) {}
+
+    /**
+     * Отображает таблицу запросов на доставку.
+     */
+    public function index(Req $req, Res $res): Res
+    {
+        $data = [
+            'title' => 'Shipping',
+        ];
+
+        return View::render($res, 'dashboard/shipping/index.php', $data, 'layouts/main.php');
+    }
+
+    /**
+     * Возвращает данные для DataTables.
+     */
+    public function data(Req $req, Res $res): Res
+    {
+        $p = (array)$req->getParsedBody();
+        $start  = max(0, (int)($p['start'] ?? 0));
+        $length = max(10, (int)($p['length'] ?? 10));
+        $draw   = (int)($p['draw'] ?? 0);
+
+        $conds = [];
+        $params = [];
+
+        if (($p['from_user_id'] ?? '') !== '') {
+            $conds[] = 'from_user_id = :from_user_id';
+            $params['from_user_id'] = $p['from_user_id'];
+        }
+        if (($p['received_from'] ?? '') !== '') {
+            $conds[] = 'received_at >= :received_from';
+            $params['received_from'] = $p['received_from'];
+        }
+        if (($p['received_to'] ?? '') !== '') {
+            $conds[] = 'received_at <= :received_to';
+            $params['received_to'] = $p['received_to'];
+        }
+        $searchValue = $p['search']['value'] ?? '';
+        if ($searchValue !== '') {
+            $conds[] = '(
+                shipping_query_id LIKE :search OR
+                CAST(from_user_id AS CHAR) LIKE :search OR
+                invoice_payload LIKE :search OR
+                shipping_address LIKE :search
+            )';
+            $params['search'] = '%' . $searchValue . '%';
+        }
+        $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
+
+        $sql = "SELECT shipping_query_id, from_user_id, invoice_payload, shipping_address, received_at FROM tg_shipping_queries {$whereSql} ORDER BY received_at DESC LIMIT :limit OFFSET :offset";
+        $stmt = $this->pdo->prepare($sql);
+        foreach ($params as $key => $val) {
+            $stmt->bindValue(':' . $key, $val);
+        }
+        $stmt->bindValue(':limit', $length, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $start, PDO::PARAM_INT);
+        $stmt->execute();
+        $rows = $stmt->fetchAll();
+
+        $countStmt = $this->pdo->prepare("SELECT COUNT(*) FROM tg_shipping_queries {$whereSql}");
+        foreach ($params as $key => $val) {
+            $countStmt->bindValue(':' . $key, $val);
+        }
+        $countStmt->execute();
+        $recordsFiltered = (int)$countStmt->fetchColumn();
+
+        $recordsTotal = (int)$this->pdo->query('SELECT COUNT(*) FROM tg_shipping_queries')->fetchColumn();
+
+        return Response::json($res, 200, [
+            'draw' => $draw,
+            'recordsTotal' => $recordsTotal,
+            'recordsFiltered' => $recordsFiltered,
+            'data' => $rows,
+        ]);
+    }
+}

--- a/public/assets/js/datatable.shipping.js
+++ b/public/assets/js/datatable.shipping.js
@@ -1,0 +1,9 @@
+$(document).ready(function() {
+  createDatatable('#shippingTable', '/dashboard/shipping/data', [
+    { data: 'shipping_query_id' },
+    { data: 'from_user_id' },
+    { data: 'invoice_payload' },
+    { data: 'shipping_address' },
+    { data: 'received_at' }
+  ]);
+});

--- a/public/index.php
+++ b/public/index.php
@@ -48,6 +48,8 @@ $app->group('/dashboard', function (\Slim\Routing\RouteCollectorProxy $g) use ($
         $auth->get('/messages/{id}/response', [\App\Controllers\Dashboard\MessagesController::class, 'download']);
         $auth->get('/pre-checkout', [\App\Controllers\Dashboard\PreCheckoutController::class, 'index']);
         $auth->post('/pre-checkout/data', [\App\Controllers\Dashboard\PreCheckoutController::class, 'data']);
+        $auth->get('/shipping', [\App\Controllers\Dashboard\ShippingQueriesController::class, 'index']);
+        $auth->post('/shipping/data', [\App\Controllers\Dashboard\ShippingQueriesController::class, 'data']);
         $auth->get('/updates', [\App\Controllers\Dashboard\UpdatesController::class, 'index']);
         $auth->post('/updates/data', [\App\Controllers\Dashboard\UpdatesController::class, 'data']);
         $auth->get('/updates/{id}', [\App\Controllers\Dashboard\UpdatesController::class, 'show']);

--- a/templates/dashboard/shipping/index.php
+++ b/templates/dashboard/shipping/index.php
@@ -1,0 +1,43 @@
+<!-- DataTables CSS -->
+<link rel="stylesheet" href="https://cdn.datatables.net/1.10.25/css/dataTables.bootstrap5.min.css">
+
+<!-- Buttons CSS -->
+<link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.3.3/css/buttons.bootstrap5.min.css">
+
+<h1>Shipping</h1>
+
+<table id="shippingTable" class="table table-center table-striped table-hover">
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>From User ID</th>
+        <th>Invoice Payload</th>
+        <th>Shipping Address</th>
+        <th>Received At</th>
+    </tr>
+    </thead>
+    <tbody></tbody>
+    <tfoot>
+    <tr>
+        <th>ID</th>
+        <th>From User ID</th>
+        <th>Invoice Payload</th>
+        <th>Shipping Address</th>
+        <th>Received At</th>
+    </tr>
+    </tfoot>
+</table>
+
+<!-- jQuery и DataTables JS -->
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.datatables.net/1.10.25/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/1.10.25/js/dataTables.bootstrap5.min.js"></script>
+
+<!-- Buttons core и HTML5-экспорт -->
+<script src="https://cdn.datatables.net/buttons/2.3.3/js/dataTables.buttons.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.3.3/js/buttons.html5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.3.3/js/buttons.bootstrap5.min.js"></script>
+
+<script src="<?= url('/assets/js/datatable.common.js') ?>"></script>
+<script src="<?= url('/assets/js/datatable.shipping.js') ?>"></script>

--- a/templates/menu.php
+++ b/templates/menu.php
@@ -17,6 +17,11 @@ $menu = [
         'icon'  => 'bi bi-receipt',
     ],
     [
+        'url'   => '/dashboard/shipping',
+        'title' => 'Shipping',
+        'icon'  => 'bi bi-truck',
+    ],
+    [
         'url'   => '/dashboard/scheduled',
         'title' => 'Scheduled',
         'icon'  => 'bi bi-clock',

--- a/tests/Unit/ShippingQueriesControllerTest.php
+++ b/tests/Unit/ShippingQueriesControllerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Controllers\Dashboard\ShippingQueriesController;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Response;
+
+final class ShippingQueriesControllerTest extends TestCase
+{
+    private PDO $pdo;
+    private ShippingQueriesController $controller;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('CREATE TABLE tg_shipping_queries (shipping_query_id TEXT PRIMARY KEY, from_user_id INTEGER, invoice_payload TEXT, shipping_address TEXT, received_at TEXT)');
+        $this->pdo->exec("INSERT INTO tg_shipping_queries (shipping_query_id, from_user_id, invoice_payload, shipping_address, received_at) VALUES ('sq1', 1, 'payload', '{}', '2024-01-01 00:00:00')");
+        $this->controller = new ShippingQueriesController($this->pdo);
+    }
+
+    public function testDataReturnsJson(): void
+    {
+        $factory = new ServerRequestFactory();
+        $req = $factory->createServerRequest('POST', '/');
+        $req = $req->withParsedBody(['draw' => 1, 'start' => 0, 'length' => 10]);
+        $res = new Response();
+        $res = $this->controller->data($req, $res);
+        $payload = json_decode((string)$res->getBody(), true);
+        $this->assertSame(1, $payload['recordsTotal']);
+        $this->assertSame('sq1', $payload['data'][0]['shipping_query_id']);
+        $this->assertSame('payload', $payload['data'][0]['invoice_payload']);
+    }
+}


### PR DESCRIPTION
## Summary
- add ShippingQueriesController with index and data endpoints
- create shipping dashboard view and DataTable JS
- register routes and menu entry for shipping queries
- cover controller with unit test

## Testing
- `composer tests` (fails: phpunit not found)


------
https://chatgpt.com/codex/tasks/task_e_68abef0f8fb8832db80cacb2b7a5a50c