### PR TITLE
Rename PDO fields to db across controllers and tests

### DIFF
--- a/app/Controllers/Api/HealthController.php
+++ b/app/Controllers/Api/HealthController.php
@@ -19,7 +19,7 @@ use App\Helpers\Response;
  */
 final class HealthController
 {
-    public function __construct(private PDO $pdo) {}
+    public function __construct(private PDO $db) {}
 
     /**
      * Проверяет работоспособность базы данных и возвращает статус.
@@ -30,7 +30,7 @@ final class HealthController
      */
     public function __invoke(Req $req, Res $res): Res
     {
-        $this->pdo->query('SELECT 1');
+        $this->db->query('SELECT 1');
         return Response::json($res, 200, ['status' => 'ok']);
     }
 }

--- a/app/Controllers/Api/UsersController.php
+++ b/app/Controllers/Api/UsersController.php
@@ -20,9 +20,9 @@ use App\Helpers\Response;
 final class UsersController
 {
     /**
-     * @param PDO $pdo Подключение к базе данных
+     * @param PDO $db Подключение к базе данных
      */
-    public function __construct(private PDO $pdo) {}
+    public function __construct(private PDO $db) {}
 
     /**
      * Возвращает список пользователей.
@@ -33,7 +33,7 @@ final class UsersController
      */
     public function list(Req $req, Res $res): Res
     {
-        $q = $this->pdo->query('SELECT id, email, created_at FROM users ORDER BY id DESC LIMIT 100');
+        $q = $this->db->query('SELECT id, email, created_at FROM users ORDER BY id DESC LIMIT 100');
         $rows = $q->fetchAll();
         return Response::json($res, 200, ['items' => $rows]);
     }
@@ -52,8 +52,8 @@ final class UsersController
         if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
             return Response::problem($res, 400, 'Validation error', ['errors' => ['email' => 'invalid']]);
         }
-        $stmt = $this->pdo->prepare('INSERT INTO users(email, created_at) VALUES(?, NOW())');
+        $stmt = $this->db->prepare('INSERT INTO users(email, created_at) VALUES(?, NOW())');
         $stmt->execute([$email]);
-        return Response::json($res, 201, ['id' => (int)$this->pdo->lastInsertId()]);
+        return Response::json($res, 201, ['id' => (int)$this->db->lastInsertId()]);
     }
 }

--- a/app/Controllers/Dashboard/ChatMembersController.php
+++ b/app/Controllers/Dashboard/ChatMembersController.php
@@ -18,7 +18,7 @@ use Psr\Http\Message\ServerRequestInterface as Req;
  */
 final class ChatMembersController
 {
-    public function __construct(private PDO $pdo) {}
+    public function __construct(private PDO $db) {}
 
     public function index(Req $req, Res $res): Res
     {
@@ -59,7 +59,7 @@ final class ChatMembersController
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
         $sql = "SELECT cm.chat_id, cm.user_id, tu.username, cm.role, cm.state FROM chat_members cm LEFT JOIN telegram_users tu ON tu.user_id = cm.user_id {$whereSql} ORDER BY cm.chat_id, cm.user_id LIMIT :limit OFFSET :offset";
-        $stmt = $this->pdo->prepare($sql);
+        $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);
         }
@@ -68,14 +68,14 @@ final class ChatMembersController
         $stmt->execute();
         $rows = $stmt->fetchAll();
 
-        $countStmt = $this->pdo->prepare("SELECT COUNT(*) FROM chat_members cm LEFT JOIN telegram_users tu ON tu.user_id = cm.user_id {$whereSql}");
+        $countStmt = $this->db->prepare("SELECT COUNT(*) FROM chat_members cm LEFT JOIN telegram_users tu ON tu.user_id = cm.user_id {$whereSql}");
         foreach ($params as $key => $val) {
             $countStmt->bindValue(':' . $key, $val);
         }
         $countStmt->execute();
         $recordsFiltered = (int)$countStmt->fetchColumn();
 
-        $recordsTotal = (int)$this->pdo->query('SELECT COUNT(*) FROM chat_members')->fetchColumn();
+        $recordsTotal = (int)$this->db->query('SELECT COUNT(*) FROM chat_members')->fetchColumn();
 
         return Response::json($res, 200, [
             'draw' => $draw,

--- a/app/Controllers/Dashboard/PanelUsersController.php
+++ b/app/Controllers/Dashboard/PanelUsersController.php
@@ -19,7 +19,7 @@ use Psr\Http\Message\ServerRequestInterface as Req;
  */
 final class PanelUsersController
 {
-    public function __construct(private PDO $pdo) {}
+    public function __construct(private PDO $db) {}
 
     /**
      * Отображает список пользователей панели.
@@ -52,7 +52,7 @@ final class PanelUsersController
         }
 
         $sql = "SELECT id, email, telegram_user_id, created_at, updated_at FROM users {$whereSql} ORDER BY id DESC LIMIT :limit OFFSET :offset";
-        $stmt = $this->pdo->prepare($sql);
+        $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);
         }
@@ -61,14 +61,14 @@ final class PanelUsersController
         $stmt->execute();
         $rows = $stmt->fetchAll();
 
-        $countStmt = $this->pdo->prepare("SELECT COUNT(*) FROM users {$whereSql}");
+        $countStmt = $this->db->prepare("SELECT COUNT(*) FROM users {$whereSql}");
         foreach ($params as $key => $val) {
             $countStmt->bindValue(':' . $key, $val);
         }
         $countStmt->execute();
         $recordsFiltered = (int)$countStmt->fetchColumn();
 
-        $recordsTotal = (int)$this->pdo->query('SELECT COUNT(*) FROM users')->fetchColumn();
+        $recordsTotal = (int)$this->db->query('SELECT COUNT(*) FROM users')->fetchColumn();
 
         return Response::json($res, 200, [
             'draw' => $draw,
@@ -115,7 +115,7 @@ final class PanelUsersController
             return View::render($res, 'dashboard/users/form.php', $params, 'layouts/main.php');
         }
 
-        $stmt = $this->pdo->prepare('INSERT INTO users (email, telegram_user_id) VALUES (:email, :telegram_user_id)');
+        $stmt = $this->db->prepare('INSERT INTO users (email, telegram_user_id) VALUES (:email, :telegram_user_id)');
         $stmt->execute([
             'email' => $email,
             'telegram_user_id' => $telegramId !== '' ? $telegramId : null,
@@ -131,7 +131,7 @@ final class PanelUsersController
     public function edit(Req $req, Res $res, array $args): Res
     {
         $id = (int)($args['id'] ?? 0);
-        $stmt = $this->pdo->prepare('SELECT id, email, telegram_user_id, created_at, updated_at FROM users WHERE id = :id');
+        $stmt = $this->db->prepare('SELECT id, email, telegram_user_id, created_at, updated_at FROM users WHERE id = :id');
         $stmt->execute(['id' => $id]);
         $user = $stmt->fetch();
         if (!$user) {
@@ -153,7 +153,7 @@ final class PanelUsersController
     public function update(Req $req, Res $res, array $args): Res
     {
         $id = (int)($args['id'] ?? 0);
-        $stmt = $this->pdo->prepare('SELECT id FROM users WHERE id = :id');
+        $stmt = $this->db->prepare('SELECT id FROM users WHERE id = :id');
         $stmt->execute(['id' => $id]);
         if (!$stmt->fetch()) {
             return $res->withStatus(404);
@@ -177,7 +177,7 @@ final class PanelUsersController
             return View::render($res, 'dashboard/users/form.php', $params, 'layouts/main.php');
         }
 
-        $stmt = $this->pdo->prepare('UPDATE users SET email = :email, telegram_user_id = :telegram_user_id WHERE id = :id');
+        $stmt = $this->db->prepare('UPDATE users SET email = :email, telegram_user_id = :telegram_user_id WHERE id = :id');
         $stmt->execute([
             'email' => $email,
             'telegram_user_id' => $telegramId !== '' ? $telegramId : null,

--- a/app/Controllers/Dashboard/PreCheckoutController.php
+++ b/app/Controllers/Dashboard/PreCheckoutController.php
@@ -18,7 +18,7 @@ use Psr\Http\Message\ServerRequestInterface as Req;
  */
 final class PreCheckoutController
 {
-    public function __construct(private PDO $pdo) {}
+    public function __construct(private PDO $db) {}
 
     /**
      * Отображает таблицу pre-checkout запросов.
@@ -77,7 +77,7 @@ final class PreCheckoutController
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
         $sql = "SELECT pre_checkout_query_id, from_user_id, currency, total_amount, shipping_option_id, received_at FROM tg_pre_checkout {$whereSql} ORDER BY received_at DESC LIMIT :limit OFFSET :offset";
-        $stmt = $this->pdo->prepare($sql);
+        $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);
         }
@@ -86,14 +86,14 @@ final class PreCheckoutController
         $stmt->execute();
         $rows = $stmt->fetchAll();
 
-        $countStmt = $this->pdo->prepare("SELECT COUNT(*) FROM tg_pre_checkout {$whereSql}");
+        $countStmt = $this->db->prepare("SELECT COUNT(*) FROM tg_pre_checkout {$whereSql}");
         foreach ($params as $key => $val) {
             $countStmt->bindValue(':' . $key, $val);
         }
         $countStmt->execute();
         $recordsFiltered = (int)$countStmt->fetchColumn();
 
-        $recordsTotal = (int)$this->pdo->query('SELECT COUNT(*) FROM tg_pre_checkout')->fetchColumn();
+        $recordsTotal = (int)$this->db->query('SELECT COUNT(*) FROM tg_pre_checkout')->fetchColumn();
 
         return Response::json($res, 200, [
             'draw' => $draw,

--- a/app/Controllers/Dashboard/SessionsController.php
+++ b/app/Controllers/Dashboard/SessionsController.php
@@ -18,7 +18,7 @@ use Psr\Http\Message\ServerRequestInterface as Req;
  */
 final class SessionsController
 {
-    public function __construct(private PDO $pdo) {}
+    public function __construct(private PDO $db) {}
 
     /**
      * Отображает таблицу сессий.
@@ -65,7 +65,7 @@ final class SessionsController
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
         $sql = "SELECT user_id, state, created_at, updated_at FROM telegram_sessions {$whereSql} ORDER BY updated_at DESC LIMIT :limit OFFSET :offset";
-        $stmt = $this->pdo->prepare($sql);
+        $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);
         }
@@ -74,14 +74,14 @@ final class SessionsController
         $stmt->execute();
         $rows = $stmt->fetchAll();
 
-        $countStmt = $this->pdo->prepare("SELECT COUNT(*) FROM telegram_sessions {$whereSql}");
+        $countStmt = $this->db->prepare("SELECT COUNT(*) FROM telegram_sessions {$whereSql}");
         foreach ($params as $key => $val) {
             $countStmt->bindValue(':' . $key, $val);
         }
         $countStmt->execute();
         $recordsFiltered = (int)$countStmt->fetchColumn();
 
-        $recordsTotal = (int)$this->pdo->query('SELECT COUNT(*) FROM telegram_sessions')->fetchColumn();
+        $recordsTotal = (int)$this->db->query('SELECT COUNT(*) FROM telegram_sessions')->fetchColumn();
 
         return Response::json($res, 200, [
             'draw' => $draw,

--- a/app/Controllers/Dashboard/ShippingQueriesController.php
+++ b/app/Controllers/Dashboard/ShippingQueriesController.php
@@ -18,7 +18,7 @@ use Psr\Http\Message\ServerRequestInterface as Req;
  */
 final class ShippingQueriesController
 {
-    public function __construct(private PDO $pdo) {}
+    public function __construct(private PDO $db) {}
 
     /**
      * Отображает таблицу запросов на доставку.
@@ -70,7 +70,7 @@ final class ShippingQueriesController
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
         $sql = "SELECT shipping_query_id, from_user_id, invoice_payload, shipping_address, received_at FROM tg_shipping_queries {$whereSql} ORDER BY received_at DESC LIMIT :limit OFFSET :offset";
-        $stmt = $this->pdo->prepare($sql);
+        $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);
         }
@@ -79,14 +79,14 @@ final class ShippingQueriesController
         $stmt->execute();
         $rows = $stmt->fetchAll();
 
-        $countStmt = $this->pdo->prepare("SELECT COUNT(*) FROM tg_shipping_queries {$whereSql}");
+        $countStmt = $this->db->prepare("SELECT COUNT(*) FROM tg_shipping_queries {$whereSql}");
         foreach ($params as $key => $val) {
             $countStmt->bindValue(':' . $key, $val);
         }
         $countStmt->execute();
         $recordsFiltered = (int)$countStmt->fetchColumn();
 
-        $recordsTotal = (int)$this->pdo->query('SELECT COUNT(*) FROM tg_shipping_queries')->fetchColumn();
+        $recordsTotal = (int)$this->db->query('SELECT COUNT(*) FROM tg_shipping_queries')->fetchColumn();
 
         return Response::json($res, 200, [
             'draw' => $draw,

--- a/app/Controllers/Dashboard/SystemController.php
+++ b/app/Controllers/Dashboard/SystemController.php
@@ -73,8 +73,8 @@ final class SystemController
             }
 
             try {
-                $pdo = Database::getInstance();
-                $stmt = $pdo->query(
+                $db = Database::getInstance();
+                $stmt = $db->query(
                     "SELECT COUNT(*) FROM telegram_messages " .
                     "WHERE status='success' AND processed_at >= DATE_SUB(NOW(), INTERVAL 1 MINUTE)"
                 );

--- a/app/Controllers/Dashboard/UpdatesController.php
+++ b/app/Controllers/Dashboard/UpdatesController.php
@@ -18,7 +18,7 @@ use Psr\Http\Message\ServerRequestInterface as Req;
  */
 final class UpdatesController
 {
-    public function __construct(private PDO $pdo) {}
+    public function __construct(private PDO $db) {}
 
     /**
      * Отображает таблицу обновлений.
@@ -73,7 +73,7 @@ final class UpdatesController
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
         $sql = "SELECT id, update_id, user_id, message_id, `type`, sent_at, created_at FROM telegram_updates {$whereSql} ORDER BY id DESC LIMIT :limit OFFSET :offset";
-        $stmt = $this->pdo->prepare($sql);
+        $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);
         }
@@ -82,14 +82,14 @@ final class UpdatesController
         $stmt->execute();
         $rows = $stmt->fetchAll();
 
-        $countStmt = $this->pdo->prepare("SELECT COUNT(*) FROM telegram_updates {$whereSql}");
+        $countStmt = $this->db->prepare("SELECT COUNT(*) FROM telegram_updates {$whereSql}");
         foreach ($params as $key => $val) {
             $countStmt->bindValue(':' . $key, $val);
         }
         $countStmt->execute();
         $recordsFiltered = (int)$countStmt->fetchColumn();
 
-        $recordsTotal = (int)$this->pdo->query('SELECT COUNT(*) FROM telegram_updates')->fetchColumn();
+        $recordsTotal = (int)$this->db->query('SELECT COUNT(*) FROM telegram_updates')->fetchColumn();
 
         return Response::json($res, 200, [
             'draw' => $draw,
@@ -105,7 +105,7 @@ final class UpdatesController
     public function show(Req $req, Res $res, array $args): Res
     {
         $id = (int)($args['id'] ?? 0);
-        $stmt = $this->pdo->prepare('SELECT data FROM telegram_updates WHERE id = :id');
+        $stmt = $this->db->prepare('SELECT data FROM telegram_updates WHERE id = :id');
         $stmt->execute(['id' => $id]);
         $row = $stmt->fetch();
         if (!$row) {

--- a/tests/Smoke/ApiTest.php
+++ b/tests/Smoke/ApiTest.php
@@ -42,9 +42,9 @@ final class ApiTest extends TestCase
         $app = AppFactory::create();
         $app->addBodyParsingMiddleware();
         $app->add(new ErrorMiddleware(true));
-        $pdo = new PDO('sqlite::memory:');
-        $app->group('/api', function (\Slim\Routing\RouteCollectorProxy $g) use ($pdo) {
-            $g->get('/health', new HealthController($pdo));
+        $db = new PDO('sqlite::memory:');
+        $app->group('/api', function (\Slim\Routing\RouteCollectorProxy $g) use ($db) {
+            $g->get('/health', new HealthController($db));
             $g->group('', function (\Slim\Routing\RouteCollectorProxy $auth) {
                 $auth->get('/me', function ($req, $res) {
                     return (new MeController())->show($req, $res);

--- a/tests/Unit/ChatJoinRequestsControllerTest.php
+++ b/tests/Unit/ChatJoinRequestsControllerTest.php
@@ -28,19 +28,19 @@ namespace Tests\Unit {
 
     final class ChatJoinRequestsControllerTest extends TestCase
     {
-        private PDO $pdo;
+        private PDO $db;
         private ChatJoinRequestsController $controller;
 
         protected function setUp(): void
         {
-            $this->pdo = new PDO('sqlite::memory:');
-            $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-            $this->pdo->exec('CREATE TABLE chat_join_requests (chat_id INTEGER, user_id INTEGER, bio TEXT, invite_link TEXT, requested_at TEXT, status TEXT, decided_at TEXT, decided_by INTEGER, PRIMARY KEY(chat_id, user_id))');
-            $this->pdo->exec('CREATE TABLE telegram_users (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, username TEXT, first_name TEXT, last_name TEXT)');
-            $this->pdo->exec('CREATE TABLE chat_members (chat_id INTEGER, user_id INTEGER, role TEXT, state TEXT, PRIMARY KEY(chat_id, user_id))');
-            $this->pdo->exec("INSERT INTO telegram_users (user_id, username, first_name, last_name) VALUES (1, 'john', 'John', 'Doe')");
-            $this->pdo->exec("INSERT INTO chat_join_requests (chat_id, user_id, bio, invite_link, requested_at, status) VALUES (100, 1, 'bio', NULL, '2024-01-01 00:00:00', 'pending')");
-            $this->controller = new ChatJoinRequestsController($this->pdo);
+            $this->db = new PDO('sqlite::memory:');
+            $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+            $this->db->exec('CREATE TABLE chat_join_requests (chat_id INTEGER, user_id INTEGER, bio TEXT, invite_link TEXT, requested_at TEXT, status TEXT, decided_at TEXT, decided_by INTEGER, PRIMARY KEY(chat_id, user_id))');
+            $this->db->exec('CREATE TABLE telegram_users (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, username TEXT, first_name TEXT, last_name TEXT)');
+            $this->db->exec('CREATE TABLE chat_members (chat_id INTEGER, user_id INTEGER, role TEXT, state TEXT, PRIMARY KEY(chat_id, user_id))');
+            $this->db->exec("INSERT INTO telegram_users (user_id, username, first_name, last_name) VALUES (1, 'john', 'John', 'Doe')");
+            $this->db->exec("INSERT INTO chat_join_requests (chat_id, user_id, bio, invite_link, requested_at, status) VALUES (100, 1, 'bio', NULL, '2024-01-01 00:00:00', 'pending')");
+            $this->controller = new ChatJoinRequestsController($this->db);
             $_SESSION = ['user_id' => 99];
         }
 
@@ -63,20 +63,20 @@ namespace Tests\Unit {
             $req = $factory->createServerRequest('POST', '/');
             $res = new Response();
             $this->controller->approve($req, $res, ['chat_id' => 100, 'user_id' => 1]);
-            $row = $this->pdo->query('SELECT status, decided_by FROM chat_join_requests WHERE chat_id = 100 AND user_id = 1')->fetch();
+            $row = $this->db->query('SELECT status, decided_by FROM chat_join_requests WHERE chat_id = 100 AND user_id = 1')->fetch();
             $this->assertSame('approved', $row['status']);
             $this->assertSame(99, (int)$row['decided_by']);
-            $m1 = $this->pdo->query('SELECT role, state FROM chat_members WHERE chat_id = 100 AND user_id = 1')->fetch();
+            $m1 = $this->db->query('SELECT role, state FROM chat_members WHERE chat_id = 100 AND user_id = 1')->fetch();
             $this->assertSame('member', $m1['role']);
             $this->assertSame('approved', $m1['state']);
 
-            $this->pdo->exec("INSERT INTO chat_join_requests (chat_id, user_id, bio, invite_link, requested_at, status) VALUES (100, 2, '', NULL, '2024-01-01 00:00:00', 'pending')");
+            $this->db->exec("INSERT INTO chat_join_requests (chat_id, user_id, bio, invite_link, requested_at, status) VALUES (100, 2, '', NULL, '2024-01-01 00:00:00', 'pending')");
             $req2 = $factory->createServerRequest('POST', '/');
             $res2 = new Response();
             $this->controller->decline($req2, $res2, ['chat_id' => 100, 'user_id' => 2]);
-            $row2 = $this->pdo->query('SELECT status FROM chat_join_requests WHERE chat_id = 100 AND user_id = 2')->fetch();
+            $row2 = $this->db->query('SELECT status FROM chat_join_requests WHERE chat_id = 100 AND user_id = 2')->fetch();
             $this->assertSame('declined', $row2['status']);
-            $m2 = $this->pdo->query('SELECT state FROM chat_members WHERE chat_id = 100 AND user_id = 2')->fetch();
+            $m2 = $this->db->query('SELECT state FROM chat_members WHERE chat_id = 100 AND user_id = 2')->fetch();
             $this->assertSame('declined', $m2['state']);
 
             $this->assertSame([

--- a/tests/Unit/ChatMembersControllerTest.php
+++ b/tests/Unit/ChatMembersControllerTest.php
@@ -12,18 +12,18 @@ use Slim\Psr7\Response;
 
 final class ChatMembersControllerTest extends TestCase
 {
-    private PDO $pdo;
+    private PDO $db;
     private ChatMembersController $controller;
 
     protected function setUp(): void
     {
-        $this->pdo = new PDO('sqlite::memory:');
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $this->pdo->exec('CREATE TABLE chat_members (chat_id INTEGER, user_id INTEGER, role TEXT, state TEXT, PRIMARY KEY(chat_id, user_id))');
-        $this->pdo->exec('CREATE TABLE telegram_users (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, username TEXT, first_name TEXT, last_name TEXT)');
-        $this->pdo->exec("INSERT INTO telegram_users (user_id, username) VALUES (1, 'john')");
-        $this->pdo->exec("INSERT INTO chat_members (chat_id, user_id, role, state) VALUES (100, 1, 'member', 'approved')");
-        $this->controller = new ChatMembersController($this->pdo);
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('CREATE TABLE chat_members (chat_id INTEGER, user_id INTEGER, role TEXT, state TEXT, PRIMARY KEY(chat_id, user_id))');
+        $this->db->exec('CREATE TABLE telegram_users (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, username TEXT, first_name TEXT, last_name TEXT)');
+        $this->db->exec("INSERT INTO telegram_users (user_id, username) VALUES (1, 'john')");
+        $this->db->exec("INSERT INTO chat_members (chat_id, user_id, role, state) VALUES (100, 1, 'member', 'approved')");
+        $this->controller = new ChatMembersController($this->db);
     }
 
     public function testDataReturnsJson(): void

--- a/tests/Unit/PreCheckoutControllerTest.php
+++ b/tests/Unit/PreCheckoutControllerTest.php
@@ -12,16 +12,16 @@ use Slim\Psr7\Response;
 
 final class PreCheckoutControllerTest extends TestCase
 {
-    private PDO $pdo;
+    private PDO $db;
     private PreCheckoutController $controller;
 
     protected function setUp(): void
     {
-        $this->pdo = new PDO('sqlite::memory:');
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $this->pdo->exec('CREATE TABLE tg_pre_checkout (pre_checkout_query_id TEXT PRIMARY KEY, from_user_id INTEGER, currency TEXT, total_amount INTEGER, invoice_payload TEXT, shipping_option_id TEXT, order_info TEXT, received_at TEXT)');
-        $this->pdo->exec("INSERT INTO tg_pre_checkout (pre_checkout_query_id, from_user_id, currency, total_amount, invoice_payload, shipping_option_id, order_info, received_at) VALUES ('abc', 1, 'USD', 1000, 'payload', 'ship1', '{}', '2024-01-01 00:00:00')");
-        $this->controller = new PreCheckoutController($this->pdo);
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('CREATE TABLE tg_pre_checkout (pre_checkout_query_id TEXT PRIMARY KEY, from_user_id INTEGER, currency TEXT, total_amount INTEGER, invoice_payload TEXT, shipping_option_id TEXT, order_info TEXT, received_at TEXT)');
+        $this->db->exec("INSERT INTO tg_pre_checkout (pre_checkout_query_id, from_user_id, currency, total_amount, invoice_payload, shipping_option_id, order_info, received_at) VALUES ('abc', 1, 'USD', 1000, 'payload', 'ship1', '{}', '2024-01-01 00:00:00')");
+        $this->controller = new PreCheckoutController($this->db);
     }
 
     public function testDataReturnsJson(): void

--- a/tests/Unit/PushInvoiceTest.php
+++ b/tests/Unit/PushInvoiceTest.php
@@ -13,20 +13,20 @@ use ReflectionClass;
 
 final class PushInvoiceTest extends TestCase
 {
-    private PDO $pdo;
+    private PDO $db;
 
     protected function setUp(): void
     {
         $_ENV['APP_ENV'] = 'test';
 
-        $this->pdo = new PDO('sqlite::memory:');
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $this->pdo->exec('CREATE TABLE telegram_messages (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, method TEXT, type TEXT, data TEXT, priority INTEGER)');
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('CREATE TABLE telegram_messages (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, method TEXT, type TEXT, data TEXT, priority INTEGER)');
 
         $dbRef = new ReflectionClass(Database::class);
         $prop = $dbRef->getProperty('instance');
         $prop->setAccessible(true);
-        $prop->setValue(null, $this->pdo);
+        $prop->setValue(null, $this->db);
 
         $redisStub = new class {
             public array $data = [];
@@ -54,7 +54,7 @@ final class PushInvoiceTest extends TestCase
         $result = Push::invoice(123, $invoice);
         $this->assertTrue($result);
 
-        $row = $this->pdo->query('SELECT user_id, method, type, data, priority FROM telegram_messages')->fetch();
+        $row = $this->db->query('SELECT user_id, method, type, data, priority FROM telegram_messages')->fetch();
         $this->assertSame(123, (int)$row['user_id']);
         $this->assertSame('sendInvoice', $row['method']);
         $data = json_decode($row['data'], true);

--- a/tests/Unit/ShippingQueriesControllerTest.php
+++ b/tests/Unit/ShippingQueriesControllerTest.php
@@ -12,16 +12,16 @@ use Slim\Psr7\Response;
 
 final class ShippingQueriesControllerTest extends TestCase
 {
-    private PDO $pdo;
+    private PDO $db;
     private ShippingQueriesController $controller;
 
     protected function setUp(): void
     {
-        $this->pdo = new PDO('sqlite::memory:');
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $this->pdo->exec('CREATE TABLE tg_shipping_queries (shipping_query_id TEXT PRIMARY KEY, from_user_id INTEGER, invoice_payload TEXT, shipping_address TEXT, received_at TEXT)');
-        $this->pdo->exec("INSERT INTO tg_shipping_queries (shipping_query_id, from_user_id, invoice_payload, shipping_address, received_at) VALUES ('sq1', 1, 'payload', '{}', '2024-01-01 00:00:00')");
-        $this->controller = new ShippingQueriesController($this->pdo);
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('CREATE TABLE tg_shipping_queries (shipping_query_id TEXT PRIMARY KEY, from_user_id INTEGER, invoice_payload TEXT, shipping_address TEXT, received_at TEXT)');
+        $this->db->exec("INSERT INTO tg_shipping_queries (shipping_query_id, from_user_id, invoice_payload, shipping_address, received_at) VALUES ('sq1', 1, 'payload', '{}', '2024-01-01 00:00:00')");
+        $this->controller = new ShippingQueriesController($this->db);
     }
 
     public function testDataReturnsJson(): void


### PR DESCRIPTION
## Summary
- rename constructor properties from `$pdo` to `$db` in API and dashboard controllers
- update tests to pass database handle as `$db`
- rename local `$pdo` variable in `SystemController` to `$db`

## Testing
- `composer tests` *(fails: "composer.json" does not contain valid JSON)*
- `phpunit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac04f70a64832dbbeba687dda05be8