### PR TITLE
Add CSP font-src directive and allow external fonts

### DIFF
--- a/app/Middleware/SecurityHeadersMiddleware.php
+++ b/app/Middleware/SecurityHeadersMiddleware.php
@@ -69,6 +69,7 @@ class SecurityHeadersMiddleware
                 $this->csp['style'] ?? null,
                 $this->csp['img'] ?? null,
                 $this->csp['connect'] ?? null,
+                $this->csp['font'] ?? null,
             );
             $response = $response->withHeader('Content-Security-Policy', $policy);
         }
@@ -84,19 +85,21 @@ class SecurityHeadersMiddleware
         return $response;
     }
 
-    private function buildCsp(?string $script, ?string $style, ?string $img, ?string $connect): string
+    private function buildCsp(?string $script, ?string $style, ?string $img, ?string $connect, ?string $font): string
     {
         $scriptSrc = $this->buildSources($script ?? ($_ENV['CSP_SCRIPT_SRC'] ?? ''));
         $styleSrc = $this->buildSources($style ?? ($_ENV['CSP_STYLE_SRC'] ?? ''), true);
         $imgSrc = $this->buildSources($img ?? ($_ENV['CSP_IMG_SRC'] ?? ''));
         $connectSrc = $this->buildSources($connect ?? ($_ENV['CSP_CONNECT_SRC'] ?? ''));
+        $fontSrc = $this->buildSources($font ?? ($_ENV['CSP_FONT_SRC'] ?? ''));
 
         return sprintf(
-            "default-src 'self'; connect-src %s; img-src %s data:; script-src %s; style-src %s; frame-ancestors 'none'",
+            "default-src 'self'; connect-src %s; img-src %s data:; script-src %s; style-src %s; font-src %s; frame-ancestors 'none'",
             $connectSrc,
             $imgSrc,
             $scriptSrc,
             $styleSrc,
+            $fontSrc,
         );
     }
 

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -6,7 +6,7 @@ server {
     root /var/www/html/public;
     index index.php index.html;
 
-    add_header Content-Security-Policy "default-src 'self'; connect-src 'self'; img-src 'self' data:; script-src 'self' https://cdn.tailwindcss.com https://cdn.datatables.net; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://cdn.datatables.net; frame-ancestors 'none';" always;
+    add_header Content-Security-Policy "default-src 'self'; connect-src 'self'; img-src 'self' data:; script-src 'self' https://cdn.tailwindcss.com https://cdn.datatables.net https://fonts.googleapis.com https://fonts.gstatic.com https://code.jquery.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://cdn.datatables.net https://fonts.googleapis.com https://fonts.gstatic.com https://code.jquery.com https://cdn.jsdelivr.net; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://code.jquery.com https://cdn.jsdelivr.net; frame-ancestors 'none';" always;
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "no-referrer" always;

--- a/tests/Unit/SecurityHeadersMiddlewareTest.php
+++ b/tests/Unit/SecurityHeadersMiddlewareTest.php
@@ -25,6 +25,7 @@ final class SecurityHeadersMiddlewareTest extends TestCase
                 'style' => 'https://styles.example',
                 'img' => 'https://img.example',
                 'connect' => 'https://api.example',
+                'font' => 'https://fonts.example',
             ],
             'x_frame_options' => 'DENY',
             'headers' => ['X-Test-Header' => 'foo'],
@@ -45,7 +46,11 @@ final class SecurityHeadersMiddlewareTest extends TestCase
         $this->assertSame('DENY', $res->getHeaderLine('X-Frame-Options'));
         $this->assertSame('foo', $res->getHeaderLine('X-Test-Header'));
         $csp = $res->getHeaderLine('Content-Security-Policy');
-        $this->assertStringContainsString('script-src', $csp);
+        $this->assertStringContainsString("script-src 'self' https://scripts.example", $csp);
+        $this->assertStringContainsString("style-src 'self' 'unsafe-inline' https://styles.example", $csp);
+        $this->assertStringContainsString("img-src 'self' https://img.example data:", $csp);
+        $this->assertStringContainsString("connect-src 'self' https://api.example", $csp);
+        $this->assertStringContainsString("font-src 'self' https://fonts.example", $csp);
     }
 
     public function testPreflightReturns204(): void


### PR DESCRIPTION
## Summary
- extend CSP middleware to handle font sources
- allow fonts and new CDNs in nginx CSP header
- cover font-src directive in middleware tests

## Testing
- ⚠️ `composer tests` (failed: "./composer.json" does not contain valid JSON)
- ⚠️ `./vendor/bin/phpunit` (failed: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68ac0ac4c958832db56ad3a66e1e0b49