### PR TITLE
refactor: move inline scripts to external files

### DIFF
--- a/public/assets/js/bootstrap-init.js
+++ b/public/assets/js/bootstrap-init.js
@@ -1,0 +1,3 @@
+// Initialize Bootstrap popovers
+const popoverTriggerList = Array.from(document.querySelectorAll('[data-bs-toggle="popover"]'));
+popoverTriggerList.forEach((popoverTriggerEl) => new bootstrap.Popover(popoverTriggerEl, { html: true }));

--- a/public/assets/js/dashboard-chart.js
+++ b/public/assets/js/dashboard-chart.js
@@ -1,0 +1,35 @@
+// Render dashboard status chart
+const canvas = document.getElementById('statusChart');
+if (canvas) {
+    const ctx = canvas.getContext('2d');
+    const labels = JSON.parse(canvas.dataset.labels || '[]');
+    const success = JSON.parse(canvas.dataset.success || '[]');
+    const failed = JSON.parse(canvas.dataset.failed || '[]');
+
+    new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: labels,
+            datasets: [
+                {
+                    label: 'success',
+                    data: success,
+                    borderColor: 'rgb(25, 135, 84)',
+                    tension: 0.1,
+                },
+                {
+                    label: 'failed',
+                    data: failed,
+                    borderColor: 'rgb(220, 53, 69)',
+                    tension: 0.1,
+                },
+            ],
+        },
+        options: {
+            responsive: true,
+            scales: {
+                y: { beginAtZero: true },
+            },
+        },
+    });
+}

--- a/templates/dashboard/index.php
+++ b/templates/dashboard/index.php
@@ -81,7 +81,10 @@
 
 <div class="row mt-3">
     <div class="col-md-12">
-        <canvas id="statusChart"></canvas>
+        <canvas id="statusChart"
+                data-labels='<?= htmlspecialchars(json_encode($chartLabels), ENT_QUOTES) ?>'
+                data-success='<?= htmlspecialchars(json_encode($chartSuccess), ENT_QUOTES) ?>'
+                data-failed='<?= htmlspecialchars(json_encode($chartFailed), ENT_QUOTES) ?>'></canvas>
     </div>
 </div>
 
@@ -114,32 +117,4 @@
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script>
-const ctx = document.getElementById('statusChart').getContext('2d');
-new Chart(ctx, {
-    type: 'line',
-    data: {
-        labels: <?= json_encode($chartLabels) ?>,
-        datasets: [
-            {
-                label: 'success',
-                data: <?= json_encode($chartSuccess) ?>,
-                borderColor: 'rgb(25, 135, 84)',
-                tension: 0.1
-            },
-            {
-                label: 'failed',
-                data: <?= json_encode($chartFailed) ?>,
-                borderColor: 'rgb(220, 53, 69)',
-                tension: 0.1
-            }
-        ]
-    },
-    options: {
-        responsive: true,
-        scales: {
-            y: { beginAtZero: true }
-        }
-    }
-});
-</script>
+<script src="<?= url('/assets/js/dashboard-chart.js') ?>"></script>

--- a/templates/layouts/main.php
+++ b/templates/layouts/main.php
@@ -93,12 +93,7 @@ $messages = Flash::get();
 
 <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-<script>
-    const popoverTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="popover"]'));
-    const popoverList = popoverTriggerList.map(function (popoverTriggerEl) {
-        return new bootstrap.Popover(popoverTriggerEl, {html: true})
-    });
-</script>
+<script src="<?= url('/assets/js/bootstrap-init.js') ?>"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extract Bootstrap popover initialization into `bootstrap-init.js` and reference from main layout
- move dashboard chart setup into `dashboard-chart.js` with data attributes for chart data

## Testing
- `composer tests` *(fails: "./composer.json" does not contain valid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0b8feb6c832d8608c92e189fa14d