### PR TITLE
Configure CSP for external CDN resources

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,12 @@ JWT_SECRET="secret"
 # разрешённые origin через запятую
 CORS_ORIGINS="*"
 
+# === Content Security Policy ===
+# дополнительные домены для CSP (через запятую)
+CSP_SCRIPT_SRC="https://code.jquery.com, https://cdn.jsdelivr.net, https://cdn.datatables.net, https://cdn.tailwindcss.com"
+CSP_STYLE_SRC="https://fonts.googleapis.com, https://cdn.jsdelivr.net, https://cdn.datatables.net, https://cdn.tailwindcss.com"
+CSP_FONT_SRC="https://fonts.gstatic.com"
+
 # === Rate limit ===
 # тип лимита: ip или user
 RATE_LIMIT_BUCKET=ip

--- a/public/index.php
+++ b/public/index.php
@@ -26,7 +26,11 @@ $app->add(new RequestSizeLimitMiddleware($config['request_size_limit']));
 $app->addBodyParsingMiddleware();
 $app->add(new SecurityHeadersMiddleware([
     'cors' => $config['cors'],
-    'csp' => [],
+    'csp' => [
+        'script' => 'https://code.jquery.com, https://cdn.jsdelivr.net, https://cdn.datatables.net, https://cdn.tailwindcss.com',
+        'style' => 'https://fonts.googleapis.com, https://cdn.jsdelivr.net, https://cdn.datatables.net, https://cdn.tailwindcss.com',
+        'font' => 'https://fonts.gstatic.com',
+    ],
     'x_frame_options' => 'DENY',
 ]));
 


### PR DESCRIPTION
## Summary
- allow CDN domains for scripts, styles, and fonts in `SecurityHeadersMiddleware`
- document CSP_* environment variables in `.env.example`

## Testing
- `php -l public/index.php`
- `composer tests` *(fails: "./composer.json" does not contain valid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0d32be40832d9f774eaa4af58819