### PR TITLE
Use middleware for CSP management

### DIFF
--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -6,7 +6,6 @@ server {
     root /var/www/html/public;
     index index.php index.html;
 
-    add_header Content-Security-Policy "default-src 'self'; connect-src 'self'; img-src 'self' data:; script-src 'self' https://cdn.tailwindcss.com https://cdn.datatables.net https://fonts.googleapis.com https://fonts.gstatic.com https://code.jquery.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://cdn.datatables.net https://fonts.googleapis.com https://fonts.gstatic.com https://code.jquery.com https://cdn.jsdelivr.net; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://code.jquery.com https://cdn.jsdelivr.net; frame-ancestors 'none';" always;
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "no-referrer" always;

--- a/tests/Unit/SecurityHeadersMiddlewareTest.php
+++ b/tests/Unit/SecurityHeadersMiddlewareTest.php
@@ -45,6 +45,7 @@ final class SecurityHeadersMiddlewareTest extends TestCase
         $this->assertSame('X-Test', $res->getHeaderLine('Access-Control-Allow-Headers'));
         $this->assertSame('DENY', $res->getHeaderLine('X-Frame-Options'));
         $this->assertSame('foo', $res->getHeaderLine('X-Test-Header'));
+        $this->assertCount(1, $res->getHeader('Content-Security-Policy'));
         $csp = $res->getHeaderLine('Content-Security-Policy');
         $this->assertStringContainsString("script-src 'self' https://scripts.example", $csp);
         $this->assertStringContainsString("style-src 'self' 'unsafe-inline' https://styles.example", $csp);


### PR DESCRIPTION
## Summary
- Remove `Content-Security-Policy` header from Nginx config to avoid duplication
- Assert that middleware emits only a single CSP header

## Testing
- `composer install` *(fails: "./composer.json" does not contain valid JSON)*
- `composer test` *(fails: "./composer.json" does not contain valid JSON)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0df2fb78832d90972d401d4c045a