### PR TITLE
feat: add responsive sidebar layout

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -89,3 +89,13 @@ code, pre {
     outline: 0;
     box-shadow: var(--bs-btn-close-focus-shadow);
 }
+
+.sidebar {
+    width: 100%;
+    min-height: 100vh;
+    background-color: #f8f9fa;
+}
+
+.main-content {
+    padding: 1rem;
+}

--- a/templates/layouts/main.php
+++ b/templates/layouts/main.php
@@ -38,7 +38,7 @@ $messages = Flash::get();
     <nav class="navbar navbar-dark bg-dark" aria-label="Dark offcanvas navbar">
         <div class="container">
             <div class="d-flex align-items-center">
-                <button class="btn btn-dark" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavbarDark" aria-controls="offcanvasNavbarDark">
+                <button class="btn btn-dark d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavbarDark" aria-controls="offcanvasNavbarDark">
                     <i class="bi bi-list"></i>
                 </button>
                 <a class="navbar-brand mx-1" href="<?= url('/dashboard') ?>">Dashboard</a>
@@ -46,7 +46,7 @@ $messages = Flash::get();
             <div class="d-flex align-items-center">
                 <!-- Правая панель -->
             </div>
-            <div class="offcanvas offcanvas-start text-bg-dark" tabindex="-1" id="offcanvasNavbarDark"
+            <div class="offcanvas offcanvas-start text-bg-dark d-lg-none" tabindex="-1" id="offcanvasNavbarDark"
                  aria-labelledby="offcanvasNavbarDarkLabel">
                 <div class="offcanvas-header">
                     <h5 class="offcanvas-title" id="offcanvasNavbarDarkLabel">Dashboard</h5>
@@ -70,22 +70,35 @@ $messages = Flash::get();
     </nav>
 </header>
 
-<main class="container">
+<main class="container-fluid">
     <div class="row">
-        <div class="col-md-12">
+        <div class="col-lg-2">
+            <nav class="sidebar d-none d-lg-block">
+                <ul class="nav nav-pills flex-column mb-auto">
+                    <?php foreach ($menu as $menuItem):?>
+                    <li class="nav-item">
+                        <a href="<?= url($menuItem['url']) ?>" class="nav-link <?= $menuItem['class'] ?>" aria-current="page">
+                            <i class="<?= $menuItem['icon'] ?>"></i>&nbsp;&nbsp;<?= $menuItem['title'] ?>
+                        </a>
+                    </li>
+                    <?php endforeach;?>
+                </ul>
+            </nav>
+        </div>
+        <div class="col-lg-10 main-content">
             <?php if (!empty($messages)): ?>
                 <?php foreach ($messages as $message): ?>
                     <div class="alert alert-<?= $message['type'] ?> alert-dismissible fade show" role="alert">
                         <?php if ($message['type'] === 'success'): ?><i class="bi bi-check-circle"></i><?php endif; ?>
                         <?php if ($message['type'] === 'info'): ?><i class="bi bi-info-circle"></i><?php endif; ?>
                         <?php if ($message['type'] === 'error' || $message['type'] === 'warning'): ?><i class="bi bi-exclamation-triangle"></i><?php endif; ?>
-                        
+
                         <?= $message['message'] ?>
                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     </div>
                 <?php endforeach; ?>
             <?php endif; ?>
-            
+
             <?= $content ?>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- wrap dashboard layout in a fluid container with a left sidebar and responsive offcanvas menu
- style sidebar and main content spacing

## Testing
- `composer tests` *(fails: "./composer.json" does not contain valid JSON)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac36b59294832daffda781758fa1a9