### PR TITLE
Add theme toggle with persistent light/dark mode

### DIFF
--- a/public/assets/js/bootstrap-init.js
+++ b/public/assets/js/bootstrap-init.js
@@ -1,3 +1,23 @@
 // Initialize Bootstrap popovers
 const popoverTriggerList = Array.from(document.querySelectorAll('[data-bs-toggle="popover"]'));
 popoverTriggerList.forEach((popoverTriggerEl) => new bootstrap.Popover(popoverTriggerEl, { html: true }));
+
+// Theme toggle
+const themeToggle = document.getElementById('theme-toggle');
+const themeIcon = themeToggle?.querySelector('i');
+
+const setTheme = (theme) => {
+    document.documentElement.dataset.bsTheme = theme;
+    localStorage.setItem('theme', theme);
+    if (themeIcon) {
+        themeIcon.className = theme === 'light' ? 'bi bi-sun' : 'bi bi-moon';
+    }
+};
+
+const storedTheme = localStorage.getItem('theme') || 'light';
+setTheme(storedTheme);
+
+themeToggle?.addEventListener('click', () => {
+    const newTheme = document.documentElement.dataset.bsTheme === 'light' ? 'dark' : 'light';
+    setTheme(newTheme);
+});

--- a/templates/layouts/centered.php
+++ b/templates/layouts/centered.php
@@ -18,13 +18,19 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="<?= url('/assets/css/bootstrap.min.css') ?>" rel="stylesheet">
+    <link href="<?= url('/assets/fonts/bootstrap-icons/bootstrap-icons.min.css'); ?>" rel="stylesheet">
     <link href="<?= url('/assets/css/login.css') ?>" rel="stylesheet">
 </head>
 <body class="d-flex align-items-center justify-content-center py-4 bg-body-tertiary">
 
+<button id="theme-toggle" class="btn btn-link position-absolute top-0 end-0 m-3">
+    <i id="theme-icon" class="bi"></i>
+</button>
+
 <?= $content ?>
 
 <script src="<?= url('/assets/js/bootstrap.bundle.min.js') ?>"></script>
+<script src="<?= url('/assets/js/bootstrap-init.js') ?>"></script>
 
 </body>
 </html>

--- a/templates/layouts/main.php
+++ b/templates/layouts/main.php
@@ -46,6 +46,9 @@ $messages = Flash::get();
             </div>
             <div class="d-flex align-items-center">
                 <!-- Правая половина шапки -->
+                <button id="theme-toggle" class="btn btn-outline-light me-2">
+                    <i id="theme-icon" class="bi"></i>
+                </button>
                 <a href="#" class="btn btn-outline-light">
                     <i class="bi bi-box-arrow-right"></i>
                     <span class="d-none d-lg-inline">Выйти</span>


### PR DESCRIPTION
## Summary
- Add theme toggle button to dashboard header
- Persist theme in localStorage and apply through bootstrap-init.js
- Include theme toggle on login layout

## Testing
- `composer tests` *(fails: "./composer.json" does not contain valid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68ac473b4bb4832d972646ceaf9931e5