### PR TITLE
Set global DataTables length menu

### DIFF
--- a/public/assets/js/datatable.common.js
+++ b/public/assets/js/datatable.common.js
@@ -18,6 +18,7 @@
         }
       },
       columns: columns,
+      lengthMenu: [[10,25,50,100,1000,-1],[10,25,50,100,1000,"Все"]],
       dom: 'Bfrtip',
       buttons: ['excel'],
       language: {

--- a/templates/pushes/index.php
+++ b/templates/pushes/index.php
@@ -67,7 +67,6 @@
         language: {
           url: 'https://cdn.datatables.net/plug-ins/2.2.2/i18n/ru.json',
         },
-        lengthMenu: [[10, 25, 50, -1], [10, 25, 50, "Все"]]
       });
     });
-</script>
+  </script>


### PR DESCRIPTION
## Summary
- configure a global DataTables length menu including 1000 and "Все" options
- drop custom length menu from pushes table so global settings apply

## Testing
- `composer tests` *(fails: "./composer.json" does not contain valid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68ac55290420832dabd8c2540de552bb