### PR TITLE
Arrange datatable toolbar in single row

### DIFF
--- a/public/assets/js/datatable.common.js
+++ b/public/assets/js/datatable.common.js
@@ -20,7 +20,7 @@
       columns: columns,
       lengthMenu: [[10,25,50,100,1000,-1],[10,25,50,100,1000,"Все"]],
       lengthChange: true,
-      dom: 'Blfrtip',
+      dom: "<'d-flex align-items-center'lfB>rtip",
       buttons: ['excel'],
       language: {
         url: "https://cdn.datatables.net/plug-ins/1.10.25/i18n/Russian.json"


### PR DESCRIPTION
## Summary
- Place datatable length selector, search input, and Excel export button on one line

## Testing
- `composer tests` *(fails: "./composer.json" does not contain valid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5cf40c74832d8784bd57e5d4a9c4