### PR TITLE
Handle unlimited DataTables length

### DIFF
--- a/app/Controllers/Dashboard/MessagesController.php
+++ b/app/Controllers/Dashboard/MessagesController.php
@@ -39,8 +39,11 @@ final class MessagesController
     {
         $p = (array)$req->getParsedBody();
         $start  = max(0, (int)($p['start'] ?? 0));
-        $length = max(10, (int)($p['length'] ?? 10));
+        $length = (int)($p['length'] ?? 10);
         $draw   = (int)($p['draw'] ?? 0);
+        if ($length === -1) {
+            $start = 0;
+        }
 
         $conds = [];
         $params = [];
@@ -80,13 +83,15 @@ final class MessagesController
         }
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
-        $sql = "SELECT id, user_id, method, `type`, status, priority, error, code, processed_at FROM telegram_messages {$whereSql} ORDER BY id DESC LIMIT :limit OFFSET :offset";
+        $sql = "SELECT id, user_id, method, `type`, status, priority, error, code, processed_at FROM telegram_messages {$whereSql} ORDER BY id DESC";
         $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);
         }
-        $stmt->bindValue(':limit', $length, PDO::PARAM_INT);
-        $stmt->bindValue(':offset', $start, PDO::PARAM_INT);
+        if ($length > 0) {
+            $stmt->bindValue(':limit', $length, PDO::PARAM_INT);
+            $stmt->bindValue(':offset', $start, PDO::PARAM_INT);
+        }
         $stmt->execute();
         $rows = $stmt->fetchAll();
 

--- a/app/Controllers/Dashboard/PanelUsersController.php
+++ b/app/Controllers/Dashboard/PanelUsersController.php
@@ -40,8 +40,11 @@ final class PanelUsersController
     {
         $p = (array)$req->getParsedBody();
         $start  = max(0, (int)($p['start'] ?? 0));
-        $length = max(10, (int)($p['length'] ?? 10));
+        $length = (int)($p['length'] ?? 10);
         $draw   = (int)($p['draw'] ?? 0);
+        if ($length === -1) {
+            $start = 0;
+        }
 
         $params = [];
         $searchValue = $p['search']['value'] ?? '';
@@ -51,13 +54,15 @@ final class PanelUsersController
             $params['search'] = '%' . $searchValue . '%';
         }
 
-        $sql = "SELECT id, email, telegram_user_id, created_at, updated_at FROM users {$whereSql} ORDER BY id DESC LIMIT :limit OFFSET :offset";
+        $sql = "SELECT id, email, telegram_user_id, created_at, updated_at FROM users {$whereSql} ORDER BY id DESC";
         $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);
         }
-        $stmt->bindValue(':limit', $length, PDO::PARAM_INT);
-        $stmt->bindValue(':offset', $start, PDO::PARAM_INT);
+        if ($length > 0) {
+            $stmt->bindValue(':limit', $length, PDO::PARAM_INT);
+            $stmt->bindValue(':offset', $start, PDO::PARAM_INT);
+        }
         $stmt->execute();
         $rows = $stmt->fetchAll();
 

--- a/app/Controllers/Dashboard/PreCheckoutController.php
+++ b/app/Controllers/Dashboard/PreCheckoutController.php
@@ -39,8 +39,11 @@ final class PreCheckoutController
     {
         $p = (array)$req->getParsedBody();
         $start  = max(0, (int)($p['start'] ?? 0));
-        $length = max(10, (int)($p['length'] ?? 10));
+        $length = (int)($p['length'] ?? 10);
         $draw   = (int)($p['draw'] ?? 0);
+        if ($length === -1) {
+            $start = 0;
+        }
 
         $conds = [];
         $params = [];
@@ -76,13 +79,15 @@ final class PreCheckoutController
         }
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
-        $sql = "SELECT pre_checkout_query_id, from_user_id, currency, total_amount, shipping_option_id, received_at FROM tg_pre_checkout {$whereSql} ORDER BY received_at DESC LIMIT :limit OFFSET :offset";
+        $sql = "SELECT pre_checkout_query_id, from_user_id, currency, total_amount, shipping_option_id, received_at FROM tg_pre_checkout {$whereSql} ORDER BY received_at DESC";
         $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);
         }
-        $stmt->bindValue(':limit', $length, PDO::PARAM_INT);
-        $stmt->bindValue(':offset', $start, PDO::PARAM_INT);
+        if ($length > 0) {
+            $stmt->bindValue(':limit', $length, PDO::PARAM_INT);
+            $stmt->bindValue(':offset', $start, PDO::PARAM_INT);
+        }
         $stmt->execute();
         $rows = $stmt->fetchAll();
 

--- a/app/Controllers/Dashboard/UpdatesController.php
+++ b/app/Controllers/Dashboard/UpdatesController.php
@@ -39,8 +39,11 @@ final class UpdatesController
     {
         $p = (array)$req->getParsedBody();
         $start  = max(0, (int)($p['start'] ?? 0));
-        $length = max(10, (int)($p['length'] ?? 10));
+        $length = (int)($p['length'] ?? 10);
         $draw   = (int)($p['draw'] ?? 0);
+        if ($length === -1) {
+            $start = 0;
+        }
 
         $conds = [];
         $params = [];
@@ -72,13 +75,15 @@ final class UpdatesController
         }
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
-        $sql = "SELECT id, update_id, user_id, message_id, `type`, sent_at, created_at FROM telegram_updates {$whereSql} ORDER BY id DESC LIMIT :limit OFFSET :offset";
+        $sql = "SELECT id, update_id, user_id, message_id, `type`, sent_at, created_at FROM telegram_updates {$whereSql} ORDER BY id DESC";
         $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);
         }
-        $stmt->bindValue(':limit', $length, PDO::PARAM_INT);
-        $stmt->bindValue(':offset', $start, PDO::PARAM_INT);
+        if ($length > 0) {
+            $stmt->bindValue(':limit', $length, PDO::PARAM_INT);
+            $stmt->bindValue(':offset', $start, PDO::PARAM_INT);
+        }
         $stmt->execute();
         $rows = $stmt->fetchAll();
 


### PR DESCRIPTION
## Summary
- allow `length = -1` in dashboard data endpoints to disable server-side LIMIT/OFFSET
- only apply pagination when length > 0 and reset start when fetching all rows

## Testing
- `composer install --no-interaction` *(failed: /usr/bin/composer: No such file or directory)*
- `./vendor/bin/phpunit` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac60a0e404832dbaca1ad90979565e