### PR TITLE
Ensure SQL pagination parameters are bound in dashboard controllers

### DIFF
--- a/app/Controllers/Dashboard/ChatJoinRequestsController.php
+++ b/app/Controllers/Dashboard/ChatJoinRequestsController.php
@@ -69,6 +69,9 @@ final class ChatJoinRequestsController
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
         $sql = "SELECT c.chat_id, c.user_id, tu.username, c.bio, c.invite_link, c.requested_at, c.status, c.decided_at, c.decided_by FROM chat_join_requests c LEFT JOIN telegram_users tu ON tu.user_id = c.user_id {$whereSql} ORDER BY c.requested_at DESC";
+        if ($length > 0) {
+            $sql .= ' LIMIT :limit OFFSET :offset';
+        }
         $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);

--- a/app/Controllers/Dashboard/ChatMembersController.php
+++ b/app/Controllers/Dashboard/ChatMembersController.php
@@ -58,13 +58,18 @@ final class ChatMembersController
         }
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
-        $sql = "SELECT cm.chat_id, cm.user_id, tu.username, cm.role, cm.state FROM chat_members cm LEFT JOIN telegram_users tu ON tu.user_id = cm.user_id {$whereSql} ORDER BY cm.chat_id, cm.user_id LIMIT :limit OFFSET :offset";
+        $sql = "SELECT cm.chat_id, cm.user_id, tu.username, cm.role, cm.state FROM chat_members cm LEFT JOIN telegram_users tu ON tu.user_id = cm.user_id {$whereSql} ORDER BY cm.chat_id, cm.user_id";
+        if ($length > 0) {
+            $sql .= ' LIMIT :limit OFFSET :offset';
+        }
         $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);
         }
-        $stmt->bindValue(':limit', $length, PDO::PARAM_INT);
-        $stmt->bindValue(':offset', $start, PDO::PARAM_INT);
+        if ($length > 0) {
+            $stmt->bindValue(':limit', $length, PDO::PARAM_INT);
+            $stmt->bindValue(':offset', $start, PDO::PARAM_INT);
+        }
         $stmt->execute();
         $rows = $stmt->fetchAll();
 

--- a/app/Controllers/Dashboard/MessagesController.php
+++ b/app/Controllers/Dashboard/MessagesController.php
@@ -84,6 +84,9 @@ final class MessagesController
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
         $sql = "SELECT id, user_id, method, `type`, status, priority, error, code, processed_at FROM telegram_messages {$whereSql} ORDER BY id DESC";
+        if ($length > 0) {
+            $sql .= ' LIMIT :limit OFFSET :offset';
+        }
         $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);

--- a/app/Controllers/Dashboard/PanelUsersController.php
+++ b/app/Controllers/Dashboard/PanelUsersController.php
@@ -55,6 +55,9 @@ final class PanelUsersController
         }
 
         $sql = "SELECT id, email, telegram_user_id, created_at, updated_at FROM users {$whereSql} ORDER BY id DESC";
+        if ($length > 0) {
+            $sql .= ' LIMIT :limit OFFSET :offset';
+        }
         $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);

--- a/app/Controllers/Dashboard/PreCheckoutController.php
+++ b/app/Controllers/Dashboard/PreCheckoutController.php
@@ -80,6 +80,9 @@ final class PreCheckoutController
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
         $sql = "SELECT pre_checkout_query_id, from_user_id, currency, total_amount, shipping_option_id, received_at FROM tg_pre_checkout {$whereSql} ORDER BY received_at DESC";
+        if ($length > 0) {
+            $sql .= ' LIMIT :limit OFFSET :offset';
+        }
         $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);

--- a/app/Controllers/Dashboard/ScheduledController.php
+++ b/app/Controllers/Dashboard/ScheduledController.php
@@ -83,6 +83,9 @@ final class ScheduledController
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
         $sql = "SELECT id, user_id, method, `type`, priority, send_after, created_at FROM telegram_scheduled_messages {$whereSql} ORDER BY id DESC";
+        if ($length > 0) {
+            $sql .= ' LIMIT :limit OFFSET :offset';
+        }
         $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);

--- a/app/Controllers/Dashboard/SessionsController.php
+++ b/app/Controllers/Dashboard/SessionsController.php
@@ -68,6 +68,9 @@ final class SessionsController
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
         $sql = "SELECT user_id, state, created_at, updated_at FROM telegram_sessions {$whereSql} ORDER BY updated_at DESC";
+        if ($length > 0) {
+            $sql .= ' LIMIT :limit OFFSET :offset';
+        }
         $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);

--- a/app/Controllers/Dashboard/ShippingQueriesController.php
+++ b/app/Controllers/Dashboard/ShippingQueriesController.php
@@ -73,6 +73,9 @@ final class ShippingQueriesController
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
         $sql = "SELECT shipping_query_id, from_user_id, invoice_payload, shipping_address, received_at FROM tg_shipping_queries {$whereSql} ORDER BY received_at DESC";
+        if ($length > 0) {
+            $sql .= ' LIMIT :limit OFFSET :offset';
+        }
         $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);

--- a/app/Controllers/Dashboard/TgUsersController.php
+++ b/app/Controllers/Dashboard/TgUsersController.php
@@ -71,6 +71,9 @@ final class TgUsersController
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
         $sql = "SELECT id, user_id, username, first_name, last_name, language_code, is_premium, is_user_banned, is_bot_banned, is_subscribed, utm, referral_code FROM telegram_users {$whereSql} ORDER BY id DESC";
+        if ($length > 0) {
+            $sql .= ' LIMIT :limit OFFSET :offset';
+        }
         $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);

--- a/app/Controllers/Dashboard/TokensController.php
+++ b/app/Controllers/Dashboard/TokensController.php
@@ -72,6 +72,9 @@ final class TokensController
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
         $sql = "SELECT id, user_id, jti, FROM_UNIXTIME(expires_at) AS expires_at, revoked, created_at, updated_at FROM refresh_tokens {$whereSql} ORDER BY id DESC";
+        if ($length > 0) {
+            $sql .= ' LIMIT :limit OFFSET :offset';
+        }
         $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);

--- a/app/Controllers/Dashboard/UpdatesController.php
+++ b/app/Controllers/Dashboard/UpdatesController.php
@@ -76,6 +76,9 @@ final class UpdatesController
         $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
 
         $sql = "SELECT id, update_id, user_id, message_id, `type`, sent_at, created_at FROM telegram_updates {$whereSql} ORDER BY id DESC";
+        if ($length > 0) {
+            $sql .= ' LIMIT :limit OFFSET :offset';
+        }
         $stmt = $this->db->prepare($sql);
         foreach ($params as $key => $val) {
             $stmt->bindValue(':' . $key, $val);


### PR DESCRIPTION
## Summary
- Append LIMIT/OFFSET clauses before preparing SQL in dashboard data endpoints
- Bind pagination parameters as integers to prevent SQL errors

## Testing
- `composer cs` *(fails: `"./composer.json" does not contain valid JSON`)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac64367b14832da77a129ff309b561