### PR TITLE
feat: add ajax user management for groups

### DIFF
--- a/public/assets/js/tg-groups-edit.js
+++ b/public/assets/js/tg-groups-edit.js
@@ -1,0 +1,72 @@
+$(function () {
+  const csrfToken = window.csrfToken || $('meta[name="csrf-token"]').attr('content');
+  window.csrfToken = csrfToken;
+  const searchUrl = window.tgUserSearchUrl;
+  const addUrl = window.tgGroupAddUrl;
+  const removeUrl = window.tgGroupRemoveUrl;
+
+  const $searchInput = $('#userSearchInput');
+  const $results = $('#userSearchResults');
+  const $membersTable = $('#membersTable');
+  const $membersBody = $('#membersTable tbody');
+  const $noMembers = $('#noMembers');
+
+  let searchTimer;
+
+  $searchInput.on('input', function () {
+    const q = $(this).val().trim();
+    clearTimeout(searchTimer);
+    if (q.length < 2) {
+      $results.empty();
+      return;
+    }
+    searchTimer = setTimeout(function () {
+      $.post(searchUrl, {
+        _csrf_token: csrfToken,
+        user_id: q,
+        username: q,
+        first_name: q,
+        last_name: q
+      }, function (data) {
+        $results.empty();
+        data.forEach(function (u) {
+          const name = u.username ? '@' + u.username : ((u.first_name || '') + ' ' + (u.last_name || '')).trim();
+          $results.append('<li class="list-group-item d-flex justify-content-between align-items-center">'
+            + '<span>' + name + ' (' + u.user_id + ')</span>'
+            + '<button type="button" class="btn btn-sm btn-secondary add-user-btn" data-user-id="' + u.user_id + '">Add</button>'
+            + '</li>');
+        });
+      }, 'json');
+    }, 300);
+  });
+
+  $results.on('click', '.add-user-btn', function () {
+    const telegramId = $(this).data('user-id');
+    $.post(addUrl, {_csrf_token: csrfToken, user_id: telegramId}, function (resp) {
+      if (!resp.user) {
+        return;
+      }
+      const u = resp.user;
+      $membersBody.prepend('<tr data-member-id="' + u.id + '">'
+        + '<td>' + u.id + '</td>'
+        + '<td>' + u.user_id + '</td>'
+        + '<td>' + (u.username || '') + '</td>'
+        + '<td><button type="button" class="btn btn-sm btn-danger remove-member-btn" data-user-id="' + u.id + '">Remove</button></td>'
+        + '</tr>');
+      $membersTable.removeClass('d-none');
+      $noMembers.addClass('d-none');
+    }, 'json');
+  });
+
+  $membersTable.on('click', '.remove-member-btn', function () {
+    const $btn = $(this);
+    const userId = $btn.data('user-id');
+    $.post(removeUrl, {_csrf_token: csrfToken, user_id: userId}, function () {
+      $btn.closest('tr').remove();
+      if ($membersBody.children().length === 0) {
+        $membersTable.addClass('d-none');
+        $noMembers.removeClass('d-none');
+      }
+    }, 'json');
+  });
+});

--- a/templates/dashboard/tg-groups/view.php
+++ b/templates/dashboard/tg-groups/view.php
@@ -15,19 +15,14 @@
 </form>
 
 <h2 class="h5">Add user</h2>
-<form method="post" class="mb-4" action="<?= url('/dashboard/tg-groups/' . $group['id'] . '/add-user') ?>">
-    <input type="hidden" name="<?= env('CSRF_TOKEN_NAME', '_csrf_token') ?>" value="<?= $csrfToken ?>">
-    <div class="input-group">
-        <input type="number" class="form-control" name="user_id" placeholder="Telegram user ID">
-        <button type="submit" class="btn btn-secondary">Add</button>
-    </div>
-</form>
+<div class="mb-4">
+    <input type="text" class="form-control mb-2" id="userSearchInput" placeholder="Search by username or ID">
+    <ul class="list-group" id="userSearchResults"></ul>
+</div>
 
 <h2 class="h5">Members</h2>
-<?php if (empty($members)): ?>
-    <p>No members</p>
-<?php else: ?>
-<table class="table table-striped">
+<p id="noMembers" class="<?= empty($members) ? '' : 'd-none' ?>">No members</p>
+<table class="table table-striped <?= empty($members) ? 'd-none' : '' ?>" id="membersTable">
     <thead>
     <tr>
         <th>ID</th>
@@ -38,19 +33,19 @@
     </thead>
     <tbody>
     <?php foreach ($members as $m): ?>
-        <tr>
+        <tr data-member-id="<?= $m['id'] ?>">
             <td><?= $m['id'] ?></td>
             <td><?= $m['user_id'] ?></td>
             <td><?= htmlspecialchars($m['username'] ?? '') ?></td>
-            <td>
-                <form method="post" class="d-inline" action="<?= url('/dashboard/tg-groups/' . $group['id'] . '/remove-user') ?>">
-                    <input type="hidden" name="<?= env('CSRF_TOKEN_NAME', '_csrf_token') ?>" value="<?= $csrfToken ?>">
-                    <input type="hidden" name="user_id" value="<?= $m['id'] ?>">
-                    <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Remove user?')">Remove</button>
-                </form>
-            </td>
+            <td><button type="button" class="btn btn-sm btn-danger remove-member-btn" data-user-id="<?= $m['id'] ?>">Remove</button></td>
         </tr>
     <?php endforeach; ?>
     </tbody>
 </table>
-<?php endif; ?>
+
+<script>
+    window.tgUserSearchUrl = '<?= url('/dashboard/tg-users/search') ?>';
+    window.tgGroupAddUrl = '<?= url('/dashboard/tg-groups/' . $group['id'] . '/add-user') ?>';
+    window.tgGroupRemoveUrl = '<?= url('/dashboard/tg-groups/' . $group['id'] . '/remove-user') ?>';
+</script>
+<script src="<?= url('/assets/js/tg-groups-edit.js') ?>"></script>


### PR DESCRIPTION
## Summary
- add JSON responses for group member add/remove
- add group member search and AJAX add/remove UI
- implement JS helper for searching and updating group members

## Testing
- `composer tests` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7264ad44832d93c6bfa413ea4fcd