### PR TITLE
Add health check service and use in dashboard controllers

### DIFF
--- a/app/Controllers/Dashboard/HomeController.php
+++ b/app/Controllers/Dashboard/HomeController.php
@@ -10,7 +10,7 @@ namespace App\Controllers\Dashboard;
 use App\Helpers\RedisHelper;
 use App\Helpers\View;
 use App\Telemetry;
-use GuzzleHttp\Client;
+use App\Services\HealthService;
 use PDO;
 use Psr\Http\Message\ResponseInterface as Res;
 use Psr\Http\Message\ServerRequestInterface as Req;
@@ -117,16 +117,9 @@ final class HomeController
             $failedData[] = $indexed[$minute]['failed'] ?? 0;
         }
 
-        // Запрос к /api/health
-        $healthOk = false;
-        try {
-            $client = new Client(['timeout' => 2.0]);
-            $resp = $client->get('http://localhost/api/health');
-            $body = json_decode((string)$resp->getBody(), true);
-            $healthOk = isset($body['status']) && $body['status'] === 'ok';
-        } catch (\Throwable) {
-            $healthOk = false;
-        }
+        // Проверка компонентов приложения
+        $health   = HealthService::check();
+        $healthOk = $health['status'] === 'ok';
 
         $queueSizes = null;
         $sendSpeed = null;

--- a/app/Controllers/Dashboard/SystemController.php
+++ b/app/Controllers/Dashboard/SystemController.php
@@ -10,7 +10,7 @@ namespace App\Controllers\Dashboard;
 use App\Helpers\Database;
 use App\Helpers\RedisHelper;
 use App\Helpers\View;
-use GuzzleHttp\Client;
+use App\Services\HealthService;
 use Psr\Http\Message\ResponseInterface as Res;
 use Psr\Http\Message\ServerRequestInterface as Req;
 
@@ -24,14 +24,7 @@ final class SystemController
      */
     public function index(Req $req, Res $res): Res
     {
-        $health = null;
-        try {
-            $client = new Client(['timeout' => 2.0]);
-            $resp   = $client->get('http://localhost/api/health');
-            $health = json_decode((string)$resp->getBody(), true);
-        } catch (\Throwable) {
-            $health = null;
-        }
+        $health = HealthService::check();
 
         $envKeys = [
             'APP_ENV',

--- a/app/Services/HealthService.php
+++ b/app/Services/HealthService.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Helpers\Database;
+use App\Helpers\RedisHelper;
+
+/**
+ * Service for checking application health components.
+ */
+final class HealthService
+{
+    /**
+     * Check health of database, Redis and worker.
+     *
+     * @return array{db: bool, redis: bool, worker: bool, status: string}
+     */
+    public static function check(): array
+    {
+        $db     = self::checkDb();
+        $redis  = self::checkRedis();
+        $worker = self::checkWorker();
+
+        return [
+            'db'     => $db,
+            'redis'  => $redis,
+            'worker' => $worker,
+            'status' => ($db && $redis && $worker) ? 'ok' : 'fail',
+        ];
+    }
+
+    /**
+     * Check database connection.
+     */
+    private static function checkDb(): bool
+    {
+        try {
+            Database::getInstance()->query('SELECT 1');
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * Check Redis connection.
+     */
+    private static function checkRedis(): bool
+    {
+        try {
+            $redis = RedisHelper::getInstance();
+            if (method_exists($redis, 'isConnected')) {
+                return (bool)$redis->isConnected();
+            }
+            return $redis->ping() !== false;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * Check whether worker process is running or lock file exists.
+     */
+    private static function checkWorker(): bool
+    {
+        try {
+            $output = @shell_exec('ps aux | grep workers/telegram.php | grep -v grep');
+            if (is_string($output) && trim($output) !== '') {
+                return true;
+            }
+        } catch (\Throwable) {
+            // ignore
+        }
+
+        $lockFile = __DIR__ . '/../../storage/worker.lock';
+        if (is_file($lockFile)) {
+            $mtime = filemtime($lockFile);
+            if ($mtime !== false && (time() - $mtime) < 60) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- add HealthService to verify database, Redis and worker processes
- replace HTTP health requests in HomeController and SystemController

## Testing
- `composer tests` (fails: phpunit: not found)
- `composer analyse` (fails: phpstan: not found)


------
https://chatgpt.com/codex/tasks/task_e_68acc0bf66d0832d8dea37aec7a38ec1