### PR TITLE
Document supervisor process naming for health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ docker compose exec app php vendor/bin/phinx migrate
 
 Воркеры запускаются через Supervisor. Конфиги лежат в `docker/supervisor`. На VPS скопируй их в `/etc/supervisor/` и включи службу `supervisor`.
 
+Supervisor использует следующие имена процессов:
+
+- Telegram workers: `tg:tg-{index}`
+- Longpolling worker: `lp`
+- GPT workers: `gpt:gpt-{index}`
+
+Проверки здоровья опираются на эти имена.
+
 Управление воркерами:
 
 ```bash


### PR DESCRIPTION
## Summary
- document Supervisor process names for workers and health checks in README

## Testing
- `composer cs` *(fails: php-cs-fixer: not found)*
- `composer analyse` *(fails: phpstan: not found)*
- `composer tests` *(fails: phpunit: not found)*
- `composer arch:check` *(fails: Could not open input file: tools/ci/validate-architecture.php)*

------
https://chatgpt.com/codex/tasks/task_e_68acc6820e3c832da2bf3998c9e5258f