### PR TITLE
docs: update worker runbook for supervisorctl

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -9,8 +9,8 @@ kubectl get pods
 
 ### Воркеры
 ```bash
-ps aux | grep workers/telegram.php
-tail -n 100 storage/logs/*.log
+supervisorctl status
+supervisorctl tail workers
 ```
 
 ### Redis
@@ -30,8 +30,7 @@ kubectl rollout restart deployment app
 
 ## Перезапуск воркеров
 ```bash
-pkill -f workers/telegram.php
-php workers/telegram.php &
+supervisorctl restart workers
 ```
 
 ## Очистка очередей и логов


### PR DESCRIPTION
## Summary
- document supervisorctl for checking worker status and logs
- document supervisorctl for restarting workers

## Testing
- `composer tests` *(fails: phpunit: not found)*
- `composer cs` *(fails: php-cs-fixer: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc94c77b8832dbe30e8049f69a468