### PR TITLE
Display detailed health status on dashboard

### DIFF
--- a/app/Controllers/Dashboard/HomeController.php
+++ b/app/Controllers/Dashboard/HomeController.php
@@ -119,7 +119,6 @@ final class HomeController
 
         // Проверка компонентов приложения
         $health   = HealthService::check();
-        $healthOk = $health['status'] === 'ok';
 
         $queueSizes = null;
         $sendSpeed = null;
@@ -158,7 +157,7 @@ final class HomeController
             'chartLabels' => $labels,
             'chartSuccess' => $successData,
             'chartFailed' => $failedData,
-            'healthOk' => $healthOk,
+            'health' => $health,
             'queueSizes' => $queueSizes,
             'sendSpeed' => $sendSpeed,
         ];

--- a/templates/dashboard/index.php
+++ b/templates/dashboard/index.php
@@ -15,7 +15,7 @@
  * @var array      $chartLabels
  * @var array      $chartSuccess
  * @var array      $chartFailed
- * @var bool       $healthOk
+ * @var array{db: bool, redis: bool, worker: bool, status: string} $health
  * @var array|null $queueSizes
  * @var int|null   $sendSpeed
  */
@@ -49,7 +49,11 @@
         <div class="card">
             <div class="card-body">
             <h4>Health</h4>
-            <p class="lead"><?= $healthOk ? 'OK' : 'FAIL' ?></p>
+            <p class="lead">
+                <?= $health['db'] ? 'DB OK' : 'DB FAIL' ?>,
+                <?= $health['redis'] ? 'Redis OK' : 'Redis FAIL' ?>,
+                <?= $health['worker'] ? 'Worker OK' : 'Worker FAIL' ?>
+            </p>
         </div></div>
     </div>
 </div>

--- a/templates/dashboard/system.php
+++ b/templates/dashboard/system.php
@@ -2,7 +2,7 @@
 /**
  * System view
  *
- * @var array|null $health
+ * @var array{db: bool, redis: bool, worker: bool, status: string} $health
  * @var array $env
  * @var array $workerCommands
  * @var array|null $queueSizes
@@ -14,7 +14,11 @@
     <div class="col-md-3">
         <div class="h-100 p-3 text-bg-dark rounded-3">
             <h4>Health</h4>
-            <p class="lead"><?= isset($health['status']) && $health['status'] === 'ok' ? 'OK' : 'FAIL' ?></p>
+            <p class="lead">
+                <?= $health['db'] ? 'DB OK' : 'DB FAIL' ?>,
+                <?= $health['redis'] ? 'Redis OK' : 'Redis FAIL' ?>,
+                <?= $health['worker'] ? 'Worker OK' : 'Worker FAIL' ?>
+            </p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Show DB/Redis/Worker statuses individually on dashboard pages
- Pass full health data structure from HomeController

## Testing
- `composer tests` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acccc98d58832db6a2e8c3115e992a