### PR TITLE
Use glob patterns for supervisorctl worker commands

### DIFF
--- a/app/Controllers/Dashboard/SystemController.php
+++ b/app/Controllers/Dashboard/SystemController.php
@@ -41,11 +41,11 @@ final class SystemController
 
         $workerCommands = [
             'status' => [
-                'supervisorctl status gpt tg lp',
+                'supervisorctl status gpt:* tg:* lp',
                 'tail -n 100 storage/logs/*.log',
             ],
             'restart' => [
-                'supervisorctl restart gpt tg lp',
+                'supervisorctl restart gpt:* tg:* lp',
             ],
         ];
 


### PR DESCRIPTION
## Summary
- Update dashboard system controller to check and restart grouped workers with `supervisorctl` glob patterns
- Dashboard template continues to render command strings from `workerCommands`

## Testing
- `composer tests` *(fails: phpunit: not found)*
- `composer install` *(fails: missing ext-redis extension)*

------
https://chatgpt.com/codex/tasks/task_e_68ad43e73c30832d8d78584ec8c0ef59