### PR TITLE
Remove items endpoint documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -7,7 +7,6 @@
 - `GET /api/health` — проверка состояния сервиса
 - `POST /api/auth/login` — выдача JWT-токена по email и паролю
 - `GET /api/me` — данные текущего пользователя
-- `GET /api/items` — список товаров
 - `GET /api/users` — список пользователей
 - `POST /api/users` — создание пользователя
 
@@ -49,17 +48,6 @@ curl http://localhost:8080/api/me \
 **Ответ:**
 ```json
 {"user":{"id":1,"email":"a@b.c","created_at":"2025-01-01"}}
-```
-
-### `GET /api/items`
-```bash
-curl http://localhost:8080/api/items \
-  -H "Authorization: Bearer <jwt>" \
-  -H "X-Telegram-Init-Data: <initData>"
-```
-**Ответ:**
-```json
-{"items":[]}
 ```
 
 ### `GET /api/users`

--- a/docs/api_contracts.md
+++ b/docs/api_contracts.md
@@ -40,17 +40,6 @@
 }
 ```
 
-## GET /api/items
-### Заголовки
-- `Authorization: Bearer <token>`
-- `X-Request-Id: <uuid>`
-### Ответ
-```json
-{
-  "items": []
-}
-```
-
 ## GET /api/users
 ### Заголовки
 - `Authorization: Bearer <token>`

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -78,29 +78,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
-  /api/items:
-    get:
-      summary: Список товаров
-      security:
-        - bearerAuth: []
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  items:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Item'
-        '401':
-          description: Неавторизован
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetails'
   /api/users:
     get:
       summary: Список пользователей
@@ -184,19 +161,6 @@ components:
         created_at:
           type: string
           format: date-time
-    Item:
-      type: object
-      required:
-        - id
-        - name
-      properties:
-        id:
-          type: integer
-        name:
-          type: string
-        price:
-          type: number
-          format: float
     Order:
       type: object
       required:


### PR DESCRIPTION
## Summary
- remove `/api/items` endpoint from API overview and contracts
- drop `/api/items` path and Item schema from OpenAPI spec

## Testing
- `composer tests` *(fails: phpunit missing, unable to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7eb54e74832d8ecfe08bf67e29d7