### PR TITLE
docs: require initData and remove register step

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1,16 +1,13 @@
 # Руководство пользователя
 
+Все запросы к API должны включать `initData`. В примерах ниже он передаётся в заголовке `X-Telegram-Init-Data: <initData>`.
+
 ## Установка
-1. Зарегистрируйте пользователя, отправив запрос:
-   ```bash
-   curl -X POST /api/auth/register \
-        -H 'Content-Type: application/json' \
-        -d '{"email":"user@example.com","password":"secret"}'
-   ```
-2. Получите токен через `POST /api/auth/login`:
+1. Получите токен через `POST /api/auth/login`:
    ```bash
    curl -X POST /api/auth/login \
         -H 'Content-Type: application/json' \
+        -H 'X-Telegram-Init-Data: <initData>' \
         -d '{"email":"user@example.com","password":"secret"}'
    ```
    В ответе вернётся поле `token`, которое необходимо передавать в заголовке `Authorization: Bearer <token>` при дальнейших запросах.
@@ -18,7 +15,9 @@
 ## Основные функции
 1. **Получение профиля**
    ```bash
-   curl -H 'Authorization: Bearer <token>' /api/me
+   curl -H 'Authorization: Bearer <token>' \
+        -H 'X-Telegram-Init-Data: <initData>' \
+        /api/me
    ```
 
 ## Администрирование


### PR DESCRIPTION
## Summary
- note that all API requests must include initData
- remove registration step from user manual
- update curl examples with X-Telegram-Init-Data header

## Testing
- `composer tests` *(fails: phpunit not found)*
- `composer install --ignore-platform-req=ext-redis` *(fails: missing GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68ad827ee5a4832d8b962b847d7c9808