### PR TITLE
Add console push command for Telegram users

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,17 @@ php bin/console migrate:rollback
 
 ```bash
 php bin/console admin:create
+php bin/console push:send "Hello" --all
 ```
 
-Создаёт администратора панели управления, запрашивая email и пароль и добавляя запись в таблицу `users`.
+`admin:create` — создаёт администратора панели управления, запрашивая email и пароль и добавляя запись в таблицу `users`.
+
+`push:send` — отправляет push-сообщение пользователям Telegram. Получатели задаются параметрами:
+
+* `--all` — всем пользователям;
+* `--user=1,2,3` — по идентификаторам;
+* `--username=alice,bob` — по username;
+* `--group=support` — по группам.
 
 ---
 

--- a/app/Console/Commands/PushSendCommand.php
+++ b/app/Console/Commands/PushSendCommand.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Console\Command;
+use App\Console\Kernel;
+use App\Helpers\Database;
+use App\Helpers\Push;
+use PDO;
+
+/**
+ * Команда для отправки push-сообщений пользователям Telegram.
+ */
+final class PushSendCommand extends Command
+{
+    public string $signature = 'push:send';
+    public string $description = 'Отправить push-сообщение выбранным пользователям Telegram';
+
+    /**
+     * @param array<int, string> $arguments
+     */
+    public function handle(array $arguments, Kernel $kernel): int
+    {
+        $message = '';
+        $options = [];
+
+        foreach ($arguments as $arg) {
+            if (str_starts_with($arg, '--')) {
+                [$key, $value] = array_pad(explode('=', substr($arg, 2), 2), 2, '');
+                $options[$key] = $value;
+            } elseif ($message === '') {
+                $message = $arg;
+            }
+        }
+
+        if ($message === '') {
+            echo 'Message text is required.' . PHP_EOL;
+            return 1;
+        }
+
+        $pdo = Database::getInstance();
+        $chatIds = [];
+
+        // Все пользователи
+        if (array_key_exists('all', $options)) {
+            // Получаем всех не заблокированных пользователей
+            $stmt = $pdo->query('SELECT user_id FROM telegram_users WHERE is_user_banned = 0 AND is_bot_banned = 0');
+            $chatIds = array_map('intval', $stmt->fetchAll(PDO::FETCH_COLUMN));
+        } else {
+            // Пользователи по ID
+            if (isset($options['user']) && $options['user'] !== '') {
+                $ids = array_filter(array_map('trim', explode(',', $options['user'])), static fn($v) => $v !== '');
+                if ($ids !== []) {
+                    $placeholders = implode(',', array_fill(0, count($ids), '?'));
+                    $stmt = $pdo->prepare("SELECT user_id FROM telegram_users WHERE user_id IN ($placeholders)");
+                    $stmt->execute($ids);
+                    $chatIds = array_merge($chatIds, $stmt->fetchAll(PDO::FETCH_COLUMN));
+                }
+            }
+
+            // Пользователи по username
+            if (isset($options['username']) && $options['username'] !== '') {
+                $names = array_filter(array_map('trim', explode(',', $options['username'])), static fn($v) => $v !== '');
+                if ($names !== []) {
+                    $placeholders = implode(',', array_fill(0, count($names), '?'));
+                    $stmt = $pdo->prepare("SELECT user_id FROM telegram_users WHERE username IN ($placeholders)");
+                    $stmt->execute($names);
+                    $chatIds = array_merge($chatIds, $stmt->fetchAll(PDO::FETCH_COLUMN));
+                }
+            }
+
+            // Группы пользователей
+            if (isset($options['group']) && $options['group'] !== '') {
+                $groups = array_filter(array_map('trim', explode(',', $options['group'])), static fn($v) => $v !== '');
+                if ($groups !== []) {
+                    $numeric = array_filter($groups, static fn($g) => ctype_digit($g));
+                    $names = array_diff($groups, $numeric);
+                    $conditions = [];
+                    $params = [];
+                    if ($numeric !== []) {
+                        $conditions[] = 'g.id IN (' . implode(',', array_fill(0, count($numeric), '?')) . ')';
+                        $params = array_merge($params, $numeric);
+                    }
+                    if ($names !== []) {
+                        $conditions[] = 'g.name IN (' . implode(',', array_fill(0, count($names), '?')) . ')';
+                        $params = array_merge($params, $names);
+                    }
+                    if ($conditions !== []) {
+                        $sql = 'SELECT tu.user_id FROM telegram_user_groups g '
+                            . 'JOIN telegram_user_group_user ugu ON g.id = ugu.group_id '
+                            . 'JOIN telegram_users tu ON tu.id = ugu.user_id '
+                            . 'WHERE ' . implode(' OR ', $conditions);
+                        $stmt = $pdo->prepare($sql);
+                        $stmt->execute($params);
+                        $chatIds = array_merge($chatIds, $stmt->fetchAll(PDO::FETCH_COLUMN));
+                    }
+                }
+            }
+        }
+
+        $chatIds = array_values(array_unique(array_map('intval', $chatIds)));
+
+        if ($chatIds === []) {
+            echo 'No recipients found.' . PHP_EOL;
+            return 1;
+        }
+
+        foreach ($chatIds as $id) {
+            Push::text($id, $message);
+        }
+
+        echo 'Messages queued: ' . count($chatIds) . PHP_EOL;
+        return 0;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -18,6 +18,7 @@ class Kernel
         Commands\CreateAdminCommand::class,
         Commands\UpdateFilterCommand::class,
         Commands\WorkerHandlerCommand::class,
+        Commands\PushSendCommand::class,
     ];
 
     /**

--- a/tests/Unit/PushSendCommandTest.php
+++ b/tests/Unit/PushSendCommandTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Console\Commands\PushSendCommand;
+use App\Console\Kernel;
+use App\Helpers\Database;
+use App\Helpers\RedisHelper;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class PushSendCommandTest extends TestCase
+{
+    private PDO $db;
+    private PushSendCommand $command;
+
+    protected function setUp(): void
+    {
+        $_ENV['APP_ENV'] = 'test';
+
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('CREATE TABLE telegram_users (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, username TEXT, is_user_banned INTEGER DEFAULT 0, is_bot_banned INTEGER DEFAULT 0)');
+        $this->db->exec('CREATE TABLE telegram_messages (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, method TEXT, type TEXT, data TEXT, priority INTEGER)');
+        $this->db->exec('CREATE TABLE telegram_user_groups (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $this->db->exec('CREATE TABLE telegram_user_group_user (group_id INTEGER, user_id INTEGER)');
+
+        $this->db->exec("INSERT INTO telegram_users (id, user_id, username, is_user_banned, is_bot_banned) VALUES (1, 100, 'alice', 0, 0), (2, 101, 'bob', 0, 0), (3, 102, 'carol', 1, 0)");
+        $this->db->exec("INSERT INTO telegram_user_groups (id, name) VALUES (1, 'group1')");
+        $this->db->exec("INSERT INTO telegram_user_group_user (group_id, user_id) VALUES (1, 1), (1, 2)");
+
+        $dbRef = new ReflectionClass(Database::class);
+        $prop = $dbRef->getProperty('instance');
+        $prop->setAccessible(true);
+        $prop->setValue(null, $this->db);
+
+        $redisStub = new class {
+            public array $data = [];
+            public function set($key, $value): bool { $this->data[$key] = $value; return true; }
+            public function rPush($key, $value): bool { $this->data[$key][] = $value; return true; }
+            public function del($key): int { unset($this->data[$key]); return 1; }
+        };
+        $redisRef = new ReflectionClass(RedisHelper::class);
+        $propRedis = $redisRef->getProperty('instance');
+        $propRedis->setAccessible(true);
+        $propRedis->setValue(null, $redisStub);
+
+        $this->command = new PushSendCommand();
+    }
+
+    public function testSendAllUsers(): void
+    {
+        $kernel = new Kernel();
+        $this->command->handle(['Hello', '--all'], $kernel);
+        $rows = $this->db->query('SELECT user_id FROM telegram_messages ORDER BY user_id')->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame([100, 101], array_map('intval', $rows));
+    }
+
+    public function testSendByUserId(): void
+    {
+        $kernel = new Kernel();
+        $this->command->handle(['Hi', '--user=100'], $kernel);
+        $row = $this->db->query('SELECT user_id FROM telegram_messages')->fetchColumn();
+        $this->assertSame(100, (int)$row);
+    }
+
+    public function testSendByUsername(): void
+    {
+        $kernel = new Kernel();
+        $this->command->handle(['Yo', '--username=bob'], $kernel);
+        $row = $this->db->query('SELECT user_id FROM telegram_messages')->fetchColumn();
+        $this->assertSame(101, (int)$row);
+    }
+
+    public function testSendByGroup(): void
+    {
+        $kernel = new Kernel();
+        $this->command->handle(['Group message', '--group=group1'], $kernel);
+        $rows = $this->db->query('SELECT user_id FROM telegram_messages ORDER BY user_id')->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame([100, 101], array_map('intval', $rows));
+    }
+}


### PR DESCRIPTION
## Summary
- add `push:send` console command to queue messages for Telegram users
- document push command usage in README
- cover command behavior with unit tests

## Testing
- `composer tests` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad906f515c832da1102ea095bdbcbe