### PR TITLE
Add dashboard message sending form

### DIFF
--- a/public/assets/js/message-send.js
+++ b/public/assets/js/message-send.js
@@ -1,0 +1,68 @@
+$(function () {
+  const csrfToken = window.csrfToken || $('meta[name="csrf-token"]').attr('content');
+  window.csrfToken = csrfToken;
+  const searchUrl = window.tgUserSearchUrl;
+
+  const $modeRadios = $('input[name="mode"]');
+  const $singleSection = $('#singleUserSection');
+  const $selectedSection = $('#selectedUsersSection');
+  const $groupSection = $('#groupSection');
+
+  function toggleSections() {
+    const mode = $modeRadios.filter(':checked').val();
+    $singleSection.toggleClass('d-none', mode !== 'single');
+    $selectedSection.toggleClass('d-none', mode !== 'selected');
+    $groupSection.toggleClass('d-none', mode !== 'group');
+  }
+  $modeRadios.on('change', toggleSections);
+  toggleSections();
+
+  const $searchInput = $('#userSearchInput');
+  const $searchResults = $('#userSearchResults');
+  const $selectedUsers = $('#selectedUsers');
+  let searchTimer;
+
+  $searchInput.on('input', function () {
+    const q = $(this).val().trim();
+    clearTimeout(searchTimer);
+    if (q.length < 2) {
+      $searchResults.empty();
+      return;
+    }
+    searchTimer = setTimeout(function () {
+      $.post(searchUrl, {
+        _csrf_token: csrfToken,
+        user_id: q,
+        username: q,
+        first_name: q,
+        last_name: q
+      }, function (data) {
+        $searchResults.empty();
+        data.forEach(function (u) {
+          const name = u.username ? '@' + u.username : ((u.first_name || '') + ' ' + (u.last_name || '')).trim();
+          $searchResults.append('<li class="list-group-item d-flex justify-content-between align-items-center">'
+            + '<span>' + name + ' (' + u.user_id + ')</span>'
+            + '<button type="button" class="btn btn-sm btn-secondary add-user-btn" data-user-id="' + u.user_id + '" data-name="' + (u.username ? '@' + u.username : u.user_id) + '">Add</button>'
+            + '</li>');
+        });
+      }, 'json');
+    }, 300);
+  });
+
+  $searchResults.on('click', '.add-user-btn', function () {
+    const id = $(this).data('user-id');
+    const name = $(this).data('name');
+    if ($selectedUsers.find('li[data-user-id="' + id + '"]').length) {
+      return;
+    }
+    $selectedUsers.append('<li class="list-group-item d-flex justify-content-between align-items-center" data-user-id="' + id + '">'
+      + '<span>' + name + '</span>'
+      + '<input type="hidden" name="users[]" value="' + id + '">'
+      + '<button type="button" class="btn btn-sm btn-outline-danger remove-user">Remove</button>'
+      + '</li>');
+  });
+
+  $selectedUsers.on('click', '.remove-user', function () {
+    $(this).closest('li').remove();
+  });
+});

--- a/public/index.php
+++ b/public/index.php
@@ -50,6 +50,8 @@ $app->group('/dashboard', function (\Slim\Routing\RouteCollectorProxy $g) use ($
         $auth->get('', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\HomeController($db))->index($req, $res));
         $auth->get('/messages', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\MessagesController($db))->index($req, $res));
         $auth->post('/messages/data', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\MessagesController($db))->data($req, $res));
+        $auth->get('/messages/create', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\MessagesController($db))->create($req, $res));
+        $auth->post('/messages/send', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\MessagesController($db))->send($req, $res));
         $auth->post('/messages/{id}/resend', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\MessagesController($db))->resend($req, $res));
         $auth->get('/messages/{id}/response', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\MessagesController($db))->download($req, $res));
         $auth->get('/pre-checkout', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\PreCheckoutController($db))->index($req, $res));

--- a/templates/dashboard/messages/create.php
+++ b/templates/dashboard/messages/create.php
@@ -1,0 +1,67 @@
+<?php
+/** @var array $groups */
+/** @var array $errors */
+/** @var array $data */
+/** @var string $csrfToken */
+?>
+<h1 class="mb-3">Send message</h1>
+<?php if (!empty($errors)): ?>
+    <div class="alert alert-danger">
+        <?php foreach ($errors as $e): ?>
+            <div><?= htmlspecialchars($e) ?></div>
+        <?php endforeach; ?>
+    </div>
+<?php endif; ?>
+<form method="post" action="<?= url('/dashboard/messages/send') ?>">
+    <input type="hidden" name="<?= $_ENV['CSRF_TOKEN_NAME'] ?? '_csrf_token' ?>" value="<?= $csrfToken ?>">
+    <div class="mb-3">
+        <textarea class="form-control" name="text" rows="3" placeholder="Text message"><?= htmlspecialchars($data['text'] ?? '') ?></textarea>
+    </div>
+    <div class="mb-3">
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="mode" id="modeAll" value="all" <?= (($data['mode'] ?? '') === 'all') ? 'checked' : '' ?>>
+            <label class="form-check-label" for="modeAll">All users</label>
+        </div>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="mode" id="modeSingle" value="single" <?= (($data['mode'] ?? '') === 'single') ? 'checked' : '' ?>>
+            <label class="form-check-label" for="modeSingle">Single user</label>
+        </div>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="mode" id="modeSelected" value="selected" <?= (($data['mode'] ?? '') === 'selected') ? 'checked' : '' ?>>
+            <label class="form-check-label" for="modeSelected">Selected users</label>
+        </div>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="mode" id="modeGroup" value="group" <?= (($data['mode'] ?? '') === 'group') ? 'checked' : '' ?>>
+            <label class="form-check-label" for="modeGroup">Group</label>
+        </div>
+    </div>
+    <div id="singleUserSection" class="mb-3 d-none">
+        <input type="text" class="form-control" name="user" id="singleUserInput" placeholder="User ID or username" value="<?= htmlspecialchars($data['user'] ?? '') ?>">
+    </div>
+    <div id="selectedUsersSection" class="mb-3 d-none">
+        <input type="text" class="form-control mb-2" id="userSearchInput" placeholder="Search user">
+        <ul class="list-group mb-2" id="userSearchResults"></ul>
+        <ul class="list-group" id="selectedUsers">
+            <?php if (!empty($data['users']) && is_array($data['users'])): foreach ($data['users'] as $u): ?>
+                <li class="list-group-item d-flex justify-content-between align-items-center" data-user-id="<?= htmlspecialchars((string)$u) ?>">
+                    <span><?= htmlspecialchars((string)$u) ?></span>
+                    <input type="hidden" name="users[]" value="<?= htmlspecialchars((string)$u) ?>">
+                    <button type="button" class="btn btn-sm btn-outline-danger remove-user">Remove</button>
+                </li>
+            <?php endforeach; endif; ?>
+        </ul>
+    </div>
+    <div id="groupSection" class="mb-3 d-none">
+        <select class="form-select" name="group_id" id="groupSelect">
+            <option value="">Select group</option>
+            <?php foreach ($groups as $g): ?>
+                <option value="<?= $g['id'] ?>" <?= (($data['group_id'] ?? '') == $g['id']) ? 'selected' : '' ?>><?= htmlspecialchars($g['name']) ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+    <button type="submit" class="btn btn-primary">Send</button>
+</form>
+<script>
+    window.tgUserSearchUrl = '<?= url('/dashboard/tg-users/search') ?>';
+</script>
+<script src="<?= url('/assets/js/message-send.js') ?>"></script>

--- a/templates/menu.php
+++ b/templates/menu.php
@@ -27,6 +27,11 @@ $menu = [
         'icon'  => 'bi bi-telegram',
     ],
     [
+        'url'   => '/dashboard/messages/create',
+        'title' => 'Отправить сообщение',
+        'icon'  => 'bi bi-envelope',
+    ],
+    [
         'url'   => '/dashboard/scheduled',
         'title' => 'Расписание сообщений',
         'icon'  => 'bi bi-clock',

--- a/tests/Unit/MessagesControllerSendTest.php
+++ b/tests/Unit/MessagesControllerSendTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Controllers\Dashboard\MessagesController;
+use App\Helpers\Database;
+use App\Helpers\RedisHelper;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Response;
+
+final class MessagesControllerSendTest extends TestCase
+{
+    private PDO $db;
+    private MessagesController $controller;
+
+    protected function setUp(): void
+    {
+        $_ENV['APP_ENV'] = 'test';
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('CREATE TABLE telegram_users (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, username TEXT)');
+        $this->db->exec('CREATE TABLE telegram_user_groups (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $this->db->exec('CREATE TABLE telegram_user_group_user (group_id INTEGER, user_id INTEGER)');
+        $this->db->exec('CREATE TABLE telegram_messages (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, method TEXT, type TEXT, data TEXT, priority INTEGER)');
+        $this->db->exec("INSERT INTO telegram_users (id, user_id, username) VALUES (1,100,'alice'), (2,101,'bob'), (3,102,'carol')");
+        $this->db->exec("INSERT INTO telegram_user_groups (id, name) VALUES (1,'group1')");
+        $this->db->exec("INSERT INTO telegram_user_group_user (group_id, user_id) VALUES (1,1),(1,2)");
+        $dbRef = new ReflectionClass(Database::class);
+        $prop = $dbRef->getProperty('instance');
+        $prop->setAccessible(true);
+        $prop->setValue(null, $this->db);
+        $redisStub = new class {
+            public array $data = [];
+            public function set($key, $value): bool { $this->data[$key] = $value; return true; }
+            public function rPush($key, $value): bool { $this->data[$key][] = $value; return true; }
+            public function del($key): int { unset($this->data[$key]); return 1; }
+        };
+        $redisRef = new ReflectionClass(RedisHelper::class);
+        $propRedis = $redisRef->getProperty('instance');
+        $propRedis->setAccessible(true);
+        $propRedis->setValue(null, $redisStub);
+        $this->controller = new MessagesController($this->db);
+        $_SESSION = [];
+    }
+
+    private function send(array $body): void
+    {
+        $factory = new ServerRequestFactory();
+        $req = $factory->createServerRequest('POST', '/');
+        $req = $req->withParsedBody($body);
+        $res = new Response();
+        $this->controller->send($req, $res);
+    }
+
+    public function testSendAll(): void
+    {
+        $this->send(['text' => 'hi', 'mode' => 'all']);
+        $rows = $this->db->query('SELECT user_id FROM telegram_messages ORDER BY user_id')->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame([100, 101, 102], array_map('intval', $rows));
+    }
+
+    public function testSendSingleByUsername(): void
+    {
+        $this->send(['text' => 'hi', 'mode' => 'single', 'user' => 'bob']);
+        $row = $this->db->query('SELECT user_id FROM telegram_messages')->fetchColumn();
+        $this->assertSame(101, (int)$row);
+    }
+
+    public function testSendSelected(): void
+    {
+        $this->send(['text' => 'hi', 'mode' => 'selected', 'users' => ['100', 'bob']]);
+        $rows = $this->db->query('SELECT user_id FROM telegram_messages ORDER BY user_id')->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame([100, 101], array_map('intval', $rows));
+    }
+
+    public function testSendGroup(): void
+    {
+        $this->send(['text' => 'hi', 'mode' => 'group', 'group_id' => 1]);
+        $rows = $this->db->query('SELECT user_id FROM telegram_messages ORDER BY user_id')->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame([100, 101], array_map('intval', $rows));
+    }
+}


### PR DESCRIPTION
## Summary
- allow creating and sending messages from dashboard
- support multiple recipient modes and ajax user search
- add tests for MessagesController::send

## Testing
- `composer tests` *(fails: phpunit not found)*
- `composer install --ignore-platform-req=ext-redis` *(fails: GitHub 403 while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ad92a64bec832d94576c6178cf1b11