### PR TITLE
feat: add input media builder

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -21,3 +21,20 @@
 - `rm -f var/log/*.log` — очистка логов
 - `php workers/<worker>.php` — запуск конкретного воркера
 - `composer dump-autoload`
+
+## Отправка медиа
+
+```php
+use App\Helpers\Push;
+
+// одиночное изображение
+$photo = Push::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'Привет']);
+Push::photo(123, $photo);
+
+// медиагруппа
+$media = [
+    Push::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'Первая']),
+    Push::buildInputMedia('photo', 'https://example.com/b.jpg'),
+];
+Push::mediaGroup(123, $media);
+```

--- a/tests/Unit/PushPhotoTest.php
+++ b/tests/Unit/PushPhotoTest.php
@@ -11,7 +11,7 @@ use PDO;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
-final class PushMediaGroupTest extends TestCase
+final class PushPhotoTest extends TestCase
 {
     private PDO $db;
 
@@ -40,22 +40,19 @@ final class PushMediaGroupTest extends TestCase
         $propRedis->setValue(null, $redisStub);
     }
 
-    public function testMediaGroupQueued(): void
+    public function testPhotoQueuedFromInputMedia(): void
     {
-        $media = [
-            Push::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'One']),
-            Push::buildInputMedia('photo', 'https://example.com/b.jpg'),
-        ];
+        $media = Push::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'One']);
 
-        $result = Push::mediaGroup(321, $media);
+        $result = Push::photo(321, $media);
         $this->assertTrue($result);
 
         $row = $this->db->query('SELECT user_id, method, data FROM telegram_messages')->fetch();
         $this->assertSame(321, (int)$row['user_id']);
-        $this->assertSame('sendMediaGroup', $row['method']);
+        $this->assertSame('sendPhoto', $row['method']);
         $data = json_decode($row['data'], true);
-        $this->assertSame('https://example.com/a.jpg', $data['media'][0]['media']);
-        $this->assertSame('html', $data['media'][0]['parse_mode']);
-        $this->assertArrayNotHasKey('parse_mode', $data['media'][1]);
+        $this->assertSame('https://example.com/a.jpg', $data['photo']);
+        $this->assertSame('One', $data['caption']);
+        $this->assertSame('html', $data['parse_mode']);
     }
 }


### PR DESCRIPTION
## Summary
- add `Push::buildInputMedia` factory
- allow media senders to accept prebuilt input media arrays
- document usage for single media and groups

## Testing
- `composer tests` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9d3de200832dbc4fda76b1a69e2a