### PR TITLE
refactor: extract media builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,17 +170,18 @@ curl "http://localhost:8080/api/health?initData=<initData>"
 
 ## 🖼️ Работа с медиа-группами
 
-`Push::buildInputMedia()` помогает собрать массив [`InputMedia`](https://core.telegram.org/bots/api#inputmedia) для разных типов файлов.
+`MediaBuilder::buildInputMedia()` помогает собрать массив [`InputMedia`](https://core.telegram.org/bots/api#inputmedia) для разных типов файлов.
 Укажите тип (`photo`, `video`, `audio` или `document`), ссылку, `fileId` или путь к файлу и при необходимости подпись.
 
 ```php
 use App\Helpers\Push;
+use App\Helpers\MediaBuilder;
 
 $media = [
-    Push::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'Фото']),
-    Push::buildInputMedia('video', 'https://example.com/b.mp4', ['caption' => 'Видео']),
-    Push::buildInputMedia('audio', 'https://example.com/c.mp3'),
-    Push::buildInputMedia('document', 'https://example.com/d.pdf', ['caption' => 'Документ']),
+    MediaBuilder::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'Фото']),
+    MediaBuilder::buildInputMedia('video', 'https://example.com/b.mp4', ['caption' => 'Видео']),
+    MediaBuilder::buildInputMedia('audio', 'https://example.com/c.mp3'),
+    MediaBuilder::buildInputMedia('document', 'https://example.com/d.pdf', ['caption' => 'Документ']),
 ];
 
 Push::mediaGroup(123456789, $media);

--- a/app/Helpers/MediaBuilder.php
+++ b/app/Helpers/MediaBuilder.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Helpers;
+
+/**
+ * Подготовка структур InputMedia для Telegram API.
+ */
+class MediaBuilder
+{
+    /**
+     * Фабричный метод формирования структуры InputMedia.
+     *
+     * @param string $type    Тип медиа (photo, audio, document, video и т.д.)
+     * @param string $media   URL, fileId или путь к файлу
+     * @param array  $options Дополнительные параметры InputMedia
+     *
+     * @return array
+     */
+    public static function buildInputMedia(string $type, string $media, array $options = []): array
+    {
+        $data = [
+            'type' => $type,
+            'media' => $media,
+        ];
+
+        if (isset($options['caption']) && $options['caption'] !== '') {
+            $data['caption'] = $options['caption'];
+            $data['parse_mode'] = $options['parse_mode'] ?? 'html';
+            unset($options['caption'], $options['parse_mode']);
+        }
+
+        return array_merge($data, $options);
+    }
+
+    /**
+     * Подготавливает данные для медиа-запросов Telegram API.
+     *
+     * @param int          $chatId    Id чата
+     * @param string       $mediaType Тип медиа (photo, audio, document, video и т.д.)
+     * @param array|string $media     URL, fileId или структура InputMedia
+     * @param string       $caption   Текст подписи
+     * @param array        $options   Дополнительные параметры метода
+     *
+     * @return array
+     */
+    public static function prepareMediaData(
+        int $chatId,
+        string $mediaType,
+        array|string $media,
+        string $caption = '',
+        array $options = []
+    ): array {
+        $payload = is_array($media)
+            ? $media
+            : self::buildInputMedia($mediaType, $media, ['caption' => $caption]);
+
+        $data = [
+            'chat_id' => $chatId,
+            $mediaType => $payload['media'],
+        ];
+
+        unset($payload['type'], $payload['media']);
+
+        if ($caption !== '' && !isset($payload['caption'])) {
+            $payload['caption'] = $caption;
+        }
+
+        if (isset($payload['caption']) && !isset($payload['parse_mode'])) {
+            $payload['parse_mode'] = 'html';
+        }
+
+        return array_merge($data, $payload, $options);
+    }
+}

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -26,15 +26,16 @@
 
 ```php
 use App\Helpers\Push;
+use App\Helpers\MediaBuilder;
 
 // одиночное изображение
-$photo = Push::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'Привет']);
+$photo = MediaBuilder::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'Привет']);
 Push::photo(123, $photo);
 
 // медиагруппа
 $media = [
-    Push::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'Первая']),
-    Push::buildInputMedia('photo', 'https://example.com/b.jpg'),
+    MediaBuilder::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'Первая']),
+    MediaBuilder::buildInputMedia('photo', 'https://example.com/b.jpg'),
 ];
 Push::mediaGroup(123, $media);
 ```

--- a/tests/Unit/PushMediaGroupTest.php
+++ b/tests/Unit/PushMediaGroupTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit;
 
 use App\Helpers\Database;
 use App\Helpers\Push;
+use App\Helpers\MediaBuilder;
 use App\Helpers\RedisHelper;
 use PDO;
 use PHPUnit\Framework\TestCase;
@@ -43,8 +44,8 @@ final class PushMediaGroupTest extends TestCase
     public function testMediaGroupQueued(): void
     {
         $media = [
-            Push::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'One']),
-            Push::buildInputMedia('photo', 'https://example.com/b.jpg'),
+            MediaBuilder::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'One']),
+            MediaBuilder::buildInputMedia('photo', 'https://example.com/b.jpg'),
         ];
 
         $result = Push::mediaGroup(321, $media);

--- a/tests/Unit/PushPhotoTest.php
+++ b/tests/Unit/PushPhotoTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit;
 
 use App\Helpers\Database;
 use App\Helpers\Push;
+use App\Helpers\MediaBuilder;
 use App\Helpers\RedisHelper;
 use PDO;
 use PHPUnit\Framework\TestCase;
@@ -42,7 +43,7 @@ final class PushPhotoTest extends TestCase
 
     public function testPhotoQueuedFromInputMedia(): void
     {
-        $media = Push::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'One']);
+        $media = MediaBuilder::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'One']);
 
         $result = Push::photo(321, $media);
         $this->assertTrue($result);


### PR DESCRIPTION
## Summary
- refactor media helpers by moving InputMedia preparation to MediaBuilder
- adjust Push class to use MediaBuilder for media payloads
- update docs and tests for MediaBuilder usage

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --ignore-platform-req=ext-redis` *(fails: requires GitHub token to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ada2ed8224832db834ec681797a0e5