### PR TITLE
Handle null media parameters in Push helpers

### DIFF
--- a/app/Helpers/Push.php
+++ b/app/Helpers/Push.php
@@ -44,6 +44,7 @@ class Push
         ];
         
         $data = array_merge($data, $options);
+        $data = array_filter($data, static fn ($value) => $value !== null);
         
         return self::push($chatId, 'sendMessage', $data, $type, $priority, $sendAfter);
     }
@@ -71,6 +72,7 @@ class Push
         ?string $sendAfter = null
     ): bool {
         $data = MediaBuilder::prepareMediaData($chatId, 'photo', $photo, $caption, $options);
+        $data = array_filter($data, static fn ($value) => $value !== null);
 
         return self::push($chatId, 'sendPhoto', $data, $type, $priority, $sendAfter);
     }
@@ -97,6 +99,7 @@ class Push
         ?string $sendAfter = null
     ): bool {
         $data = MediaBuilder::prepareMediaData($chatId, 'audio', $audio, $caption, $options);
+        $data = array_filter($data, static fn ($value) => $value !== null);
 
         return self::push($chatId, 'sendAudio', $data, $type, $priority, $sendAfter);
     }
@@ -125,6 +128,7 @@ class Push
         $options = array_merge(['disable_content_type_detection' => true], $options);
 
         $data = MediaBuilder::prepareMediaData($chatId, 'document', $document, $caption, $options);
+        $data = array_filter($data, static fn ($value) => $value !== null);
 
         return self::push($chatId, 'sendDocument', $data, $type, $priority, $sendAfter);
     }
@@ -151,6 +155,7 @@ class Push
         ?string $sendAfter = null
     ): bool {
         $data = MediaBuilder::prepareMediaData($chatId, 'video', $video, $caption, $options);
+        $data = array_filter($data, static fn ($value) => $value !== null);
 
         return self::push($chatId, 'sendVideo', $data, $type, $priority, $sendAfter);
     }
@@ -175,12 +180,15 @@ class Push
         array $options = [],
         ?string $sendAfter = null
     ): bool {
+        $media = array_map(static fn ($item) => array_filter($item, static fn ($value) => $value !== null), $media);
+
         $data = [
             'chat_id' => $chatId,
             'media' => $media,
         ];
 
         $data = array_merge($data, $options);
+        $data = array_filter($data, static fn ($value) => $value !== null);
 
         return self::push($chatId, 'sendMediaGroup', $data, $type, $priority, $sendAfter);
     }
@@ -211,6 +219,7 @@ class Push
         ];
         
         $data = array_merge($data, $options);
+        $data = array_filter($data, static fn ($value) => $value !== null);
         
         return self::push($chatId, 'sendSticker', $data, $type, $priority, $sendAfter);
     }
@@ -247,6 +256,7 @@ class Push
         }
         
         $data = array_merge($data, $options);
+        $data = array_filter($data, static fn ($value) => $value !== null);
         
         return self::push($chatId, 'sendAnimation', $data, $type, $priority, $sendAfter);
     }

--- a/tests/Unit/MediaBuilderTest.php
+++ b/tests/Unit/MediaBuilderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Helpers\MediaBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class MediaBuilderTest extends TestCase
+{
+    public function testParseModeNullNotAdded(): void
+    {
+        $media = MediaBuilder::buildInputMedia('photo', 'https://example.com/a.jpg', [
+            'caption' => 'One',
+            'parse_mode' => null,
+        ]);
+
+        $this->assertArrayHasKey('caption', $media);
+        $this->assertArrayNotHasKey('parse_mode', $media);
+    }
+
+    public function testPrepareMediaDataFiltersNull(): void
+    {
+        $data = MediaBuilder::prepareMediaData(123, 'video', 'https://example.com/b.mp4', 'Video', [
+            'width' => 640,
+            'height' => null,
+            'supports_streaming' => null,
+        ]);
+
+        $this->assertArrayHasKey('width', $data);
+        $this->assertArrayNotHasKey('height', $data);
+        $this->assertArrayNotHasKey('supports_streaming', $data);
+    }
+}


### PR DESCRIPTION
## Summary
- ignore null values for InputMedia options when building media payloads
- clean up Push helpers to strip null options and media items
- add MediaBuilder tests covering null handling

## Testing
- `composer install --ignore-platform-req=ext-redis` *(fails: GitHub token/403)*
- `./vendor/bin/phpunit tests/Unit/MediaBuilderTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adb133d114832db193970daf474c7f