### PR TITLE
docs: document dashboard media sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,41 @@ $media = [
 Push::mediaGroup(123456789, $media);
 ```
 
+## 🖥️ Отправка медиа через Dashboard
+
+На странице Dashboard → Messages → Send можно отправлять сообщения с любыми типами медиа без написания кода:
+
+1. Откройте раздел **Messages** и нажмите **Send**.
+2. Выберите тип сообщения в списке **Type** — появятся доступные параметры.
+3. Заполните параметры и выберите получателей (all, single, selected или group).
+4. Нажмите **Send**.
+
+| Тип | Параметры |
+| --- | --- |
+| `text` | `text` |
+| `photo` | `caption`, `parse_mode`, `has_spoiler` |
+| `audio` | `caption`, `parse_mode`, `duration`, `performer`, `title` |
+| `video` | `caption`, `parse_mode`, `width`, `height`, `duration`, `has_spoiler` |
+| `document` | `caption`, `parse_mode` |
+| `sticker` | — |
+| `animation` | `caption`, `parse_mode`, `width`, `height`, `duration`, `has_spoiler` |
+| `voice` | `caption`, `parse_mode`, `duration` |
+| `video_note` | `length`, `duration` |
+| `media_group` | `caption`, `parse_mode` (только для первого элемента) |
+
+Файлы загружаются на сервер и сохраняются в `storage/messages`. Размер запроса ограничен переменной `.env` `REQUEST_SIZE_LIMIT` (по умолчанию 1 МБ); также действуют лимиты Telegram Bot API (например, фото/видео до 20 МБ).
+
+Пример использования опций `MediaBuilder`:
+
+```php
+$video = MediaBuilder::buildInputMedia('video', '/path/clip.mp4', [
+    'caption' => '<b>Демо</b>',
+    'parse_mode' => 'HTML',
+    'width' => 640,
+    'height' => 360,
+]);
+```
+
 ---
 
 ## 📖 Документация

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -28,14 +28,42 @@
 use App\Helpers\Push;
 use App\Helpers\MediaBuilder;
 
-// одиночное изображение
-$photo = MediaBuilder::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'Привет']);
+$photo = MediaBuilder::buildInputMedia('photo', '/path/a.jpg', [
+    'caption' => '<b>Привет</b>',
+    'parse_mode' => 'HTML',
+]);
+
+$video = MediaBuilder::buildInputMedia('video', '/path/b.mp4', [
+    'caption' => 'Клип',
+    'width' => 640,
+    'height' => 360,
+]);
+
+// одиночное фото
 Push::photo(123, $photo);
 
-// медиагруппа
-$media = [
-    MediaBuilder::buildInputMedia('photo', 'https://example.com/a.jpg', ['caption' => 'Первая']),
-    MediaBuilder::buildInputMedia('photo', 'https://example.com/b.jpg'),
-];
-Push::mediaGroup(123, $media);
+// медиагруппа с видео
+Push::mediaGroup(123, [$photo, $video]);
 ```
+
+### Через Dashboard
+
+1. Перейдите в `/dashboard/messages/create`.
+2. Выберите тип сообщения и заполните соответствующие поля.
+3. Укажите получателей и отправьте сообщение.
+
+| Тип | Параметры |
+| --- | --- |
+| `text` | `text` |
+| `photo` | `caption`, `parse_mode`, `has_spoiler` |
+| `audio` | `caption`, `parse_mode`, `duration`, `performer`, `title` |
+| `video` | `caption`, `parse_mode`, `width`, `height`, `duration`, `has_spoiler` |
+| `document` | `caption`, `parse_mode` |
+| `sticker` | — |
+| `animation` | `caption`, `parse_mode`, `width`, `height`, `duration`, `has_spoiler` |
+| `voice` | `caption`, `parse_mode`, `duration` |
+| `video_note` | `length`, `duration` |
+| `media_group` | `caption`, `parse_mode` (только для первого элемента) |
+
+Загруженные файлы сохраняются в `storage/messages`. Размер запроса ограничен переменной `REQUEST_SIZE_LIMIT` в `.env` (по умолчанию 1 МБ); также учитывайте ограничения Telegram Bot API (например, фото/видео до 20 МБ).
+


### PR DESCRIPTION
## Summary
- document dashboard media-sending flow and parameters
- expand developer guide with MediaBuilder examples

## Testing
- `composer tests` *(fails: phpunit: not found)*
- `composer install` *(fails: ext-redis missing)*

------
https://chatgpt.com/codex/tasks/task_e_68add3b62fec832d81038395cbebb080