### PR TITLE
Add dashboard file management

### DIFF
--- a/app/Controllers/Dashboard/FilesController.php
+++ b/app/Controllers/Dashboard/FilesController.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Controller for managing uploaded files.
+ */
+
+declare(strict_types=1);
+
+namespace App\Controllers\Dashboard;
+
+use App\Helpers\Flash;
+use App\Helpers\Response;
+use App\Helpers\View;
+use App\Services\FileService;
+use Longman\TelegramBot\Request;
+use PDO;
+use Psr\Http\Message\ResponseInterface as Res;
+use Psr\Http\Message\ServerRequestInterface as Req;
+
+final class FilesController
+{
+    public function __construct(private PDO $db, private FileService $files)
+    {
+    }
+
+    public function index(Req $req, Res $res): Res
+    {
+        $data = [
+            'title' => 'Files',
+        ];
+        return View::render($res, 'dashboard/files/index.php', $data, 'layouts/main.php');
+    }
+
+    public function data(Req $req, Res $res): Res
+    {
+        $p = (array)$req->getParsedBody();
+        $start  = max(0, (int)($p['start'] ?? 0));
+        $length = (int)($p['length'] ?? 10);
+        $draw   = (int)($p['draw'] ?? 0);
+        if ($length === -1) {
+            $start = 0;
+        }
+
+        $conds = [];
+        $params = [];
+        if (($p['type'] ?? '') !== '') {
+            $conds[] = 'type = :type';
+            $params['type'] = $p['type'];
+        }
+        $searchValue = $p['search']['value'] ?? '';
+        if ($searchValue !== '') {
+            $conds[] = '(original_name LIKE :search OR file_id LIKE :search)';
+            $params['search'] = '%' . $searchValue . '%';
+        }
+        $whereSql = $conds ? ('WHERE ' . implode(' AND ', $conds)) : '';
+
+        $sql = "SELECT id, type, original_name, mime_type, size, file_id, created_at FROM telegram_files {$whereSql} ORDER BY id DESC";
+        if ($length > 0) {
+            $sql .= ' LIMIT :limit OFFSET :offset';
+        }
+        $stmt = $this->db->prepare($sql);
+        foreach ($params as $key => $val) {
+            $stmt->bindValue(':' . $key, $val);
+        }
+        if ($length > 0) {
+            $stmt->bindValue(':limit', $length, PDO::PARAM_INT);
+            $stmt->bindValue(':offset', $start, PDO::PARAM_INT);
+        }
+        $stmt->execute();
+        $rows = $stmt->fetchAll();
+
+        $countStmt = $this->db->prepare("SELECT COUNT(*) FROM telegram_files {$whereSql}");
+        foreach ($params as $key => $val) {
+            $countStmt->bindValue(':' . $key, $val);
+        }
+        $countStmt->execute();
+        $recordsFiltered = (int)$countStmt->fetchColumn();
+
+        $recordsTotal = (int)$this->db->query('SELECT COUNT(*) FROM telegram_files')->fetchColumn();
+
+        return Response::json($res, 200, [
+            'draw' => $draw,
+            'recordsTotal' => $recordsTotal,
+            'recordsFiltered' => $recordsFiltered,
+            'data' => $rows,
+        ]);
+    }
+
+    public function create(Req $req, Res $res): Res
+    {
+        $params = [
+            'title' => 'Upload file',
+            'errors' => [],
+            'data' => [],
+        ];
+        return View::render($res, 'dashboard/files/create.php', $params, 'layouts/main.php');
+    }
+
+    public function store(Req $req, Res $res): Res
+    {
+        $data = (array)$req->getParsedBody();
+        $type = (string)($data['type'] ?? '');
+        $uploaded = $req->getUploadedFiles();
+        $file = $uploaded['file'] ?? null;
+
+        $errors = [];
+        if (!in_array($type, ['photo', 'document', 'audio', 'video', 'voice'], true)) {
+            $errors[] = 'Unknown type';
+        }
+        if ($file === null || $file->getError() !== UPLOAD_ERR_OK) {
+            $errors[] = 'File is required';
+        }
+
+        if (!$errors) {
+            $tmp = tempnam(sys_get_temp_dir(), 'tgf');
+            $file->moveTo($tmp);
+            $fileId = null;
+            switch ($type) {
+                case 'photo':
+                    $fileId = $this->files->sendPhoto($tmp);
+                    break;
+                case 'document':
+                    $fileId = $this->files->sendDocument($tmp);
+                    break;
+                case 'audio':
+                    $fileId = $this->files->sendAudio($tmp);
+                    break;
+                case 'video':
+                    $fileId = $this->files->sendVideo($tmp);
+                    break;
+                case 'voice':
+                    $fileId = $this->files->sendVoice($tmp);
+                    break;
+            }
+            @unlink($tmp);
+            if ($fileId !== null) {
+                Flash::add('success', 'File uploaded');
+                return $res->withHeader('Location', '/dashboard/files')->withStatus(302);
+            }
+            $errors[] = 'Failed to upload';
+        }
+
+        $params = [
+            'title' => 'Upload file',
+            'errors' => $errors,
+            'data' => ['type' => $type],
+        ];
+        return View::render($res, 'dashboard/files/create.php', $params, 'layouts/main.php');
+    }
+
+    public function show(Req $req, Res $res, array $args): Res
+    {
+        $id = (int)($args['id'] ?? 0);
+        $stmt = $this->db->prepare('SELECT type, file_id FROM telegram_files WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $row = $stmt->fetch();
+        if (!$row) {
+            return $res->withStatus(404);
+        }
+
+        $response = Request::getFile(['file_id' => $row['file_id']]);
+        $ok = method_exists($response, 'isOk') ? $response->isOk() : ($response->ok ?? false);
+        $result = $ok ? (method_exists($response, 'getResult') ? $response->getResult() : ($response->result ?? null)) : null;
+        $filePath = '';
+        if (is_object($result)) {
+            $filePath = method_exists($result, 'getFilePath') ? $result->getFilePath() : ($result->file_path ?? '');
+        } elseif (is_array($result)) {
+            $filePath = $result['file_path'] ?? '';
+        }
+        if (!$ok || $filePath === '') {
+            return $res->withStatus(500);
+        }
+
+        $token = $_ENV['BOT_TOKEN'] ?? '';
+        $url = 'https://api.telegram.org/file/bot' . $token . '/' . $filePath;
+        $html = '';
+        switch ($row['type']) {
+            case 'photo':
+                $html = '<img src="' . htmlspecialchars($url, ENT_QUOTES) . '" class="img-fluid">';
+                break;
+            case 'audio':
+            case 'voice':
+                $html = '<audio controls src="' . htmlspecialchars($url, ENT_QUOTES) . '"></audio>';
+                break;
+            case 'video':
+                $html = '<video controls src="' . htmlspecialchars($url, ENT_QUOTES) . '" class="img-fluid"></video>';
+                break;
+            default:
+                $html = '<a href="' . htmlspecialchars($url, ENT_QUOTES) . '">Download</a>';
+        }
+        $res->getBody()->write($html);
+        return $res->withHeader('Content-Type', 'text/html');
+    }
+}

--- a/public/assets/js/datatable.files.js
+++ b/public/assets/js/datatable.files.js
@@ -1,0 +1,19 @@
+$(document).ready(function() {
+  createDatatable('#filesTable', '/dashboard/files/data', [
+    { data: 'id' },
+    { data: 'type' },
+    { data: 'original_name' },
+    { data: 'mime_type' },
+    { data: 'size' },
+    { data: 'created_at' },
+    {
+      data: null,
+      className: 'text-end',
+      render: function(data, type, row) {
+        return '<a href="/dashboard/files/' + row.id + '" class="btn btn-sm btn-outline-secondary">View</a>';
+      },
+      orderable: false,
+      searchable: false
+    }
+  ]);
+});

--- a/public/index.php
+++ b/public/index.php
@@ -54,6 +54,11 @@ $app->group('/dashboard', function (\Slim\Routing\RouteCollectorProxy $g) use ($
         $auth->post('/messages/send', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\MessagesController($db))->send($req, $res));
         $auth->post('/messages/{id}/resend', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\MessagesController($db))->resend($req, $res));
         $auth->get('/messages/{id}/response', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\MessagesController($db))->download($req, $res));
+        $auth->get('/files', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\FilesController($db, new \App\Services\FileService($db)))->index($req, $res));
+        $auth->post('/files/data', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\FilesController($db, new \App\Services\FileService($db)))->data($req, $res));
+        $auth->get('/files/create', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\FilesController($db, new \App\Services\FileService($db)))->create($req, $res));
+        $auth->post('/files', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\FilesController($db, new \App\Services\FileService($db)))->store($req, $res));
+        $auth->get('/files/{id}', fn(Req $req, Res $res, array $args) => (new \App\Controllers\Dashboard\FilesController($db, new \App\Services\FileService($db)))->show($req, $res, $args));
         $auth->get('/pre-checkout', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\PreCheckoutController($db))->index($req, $res));
         $auth->post('/pre-checkout/data', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\PreCheckoutController($db))->data($req, $res));
         $auth->get('/shipping', fn(Req $req, Res $res) => (new \App\Controllers\Dashboard\ShippingQueriesController($db))->index($req, $res));

--- a/templates/dashboard/files/create.php
+++ b/templates/dashboard/files/create.php
@@ -1,0 +1,30 @@
+<?php
+/** @var array $errors */
+/** @var array $data */
+/** @var string $csrfToken */
+?>
+<h1 class="mb-3">Upload file</h1>
+<?php if (!empty($errors)): ?>
+    <div class="alert alert-danger">
+        <?php foreach ($errors as $e): ?>
+            <div><?= htmlspecialchars($e) ?></div>
+        <?php endforeach; ?>
+    </div>
+<?php endif; ?>
+<form method="post" action="<?= url('/dashboard/files') ?>" enctype="multipart/form-data">
+    <input type="hidden" name="<?= $_ENV['CSRF_TOKEN_NAME'] ?? '_csrf_token' ?>" value="<?= $csrfToken ?>">
+    <div class="mb-3">
+        <label for="fileType" class="form-label">Type</label>
+        <?php $curType = $data['type'] ?? 'photo'; ?>
+        <select class="form-select" name="type" id="fileType">
+            <?php foreach (['photo' => 'Photo', 'document' => 'Document', 'audio' => 'Audio', 'video' => 'Video', 'voice' => 'Voice'] as $val => $label): ?>
+                <option value="<?= $val ?>" <?= $curType === $val ? 'selected' : '' ?>><?= $label ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label for="fileInput" class="form-label">File</label>
+        <input class="form-control" type="file" name="file" id="fileInput">
+    </div>
+    <button type="submit" class="btn btn-primary">Upload</button>
+</form>

--- a/templates/dashboard/files/index.php
+++ b/templates/dashboard/files/index.php
@@ -1,0 +1,47 @@
+<!-- DataTables CSS -->
+<link rel="stylesheet" href="https://cdn.datatables.net/1.10.25/css/dataTables.bootstrap5.min.css">
+
+<!-- Buttons CSS -->
+<link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.3.3/css/buttons.bootstrap5.min.css">
+
+<h1>Files</h1>
+
+<table id="filesTable" class="table table-center table-striped table-hover">
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>Type</th>
+        <th>Name</th>
+        <th>MIME</th>
+        <th>Size</th>
+        <th>Created</th>
+        <th class="text-end">Actions</th>
+    </tr>
+    </thead>
+    <tbody></tbody>
+    <tfoot>
+    <tr>
+        <th>ID</th>
+        <th>Type</th>
+        <th>Name</th>
+        <th>MIME</th>
+        <th>Size</th>
+        <th>Created</th>
+        <th class="text-end">Actions</th>
+    </tr>
+    </tfoot>
+</table>
+
+<!-- jQuery и DataTables JS -->
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.datatables.net/1.10.25/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/1.10.25/js/dataTables.bootstrap5.min.js"></script>
+
+<!-- Buttons core и HTML5-экспорт -->
+<script src="https://cdn.datatables.net/buttons/2.3.3/js/dataTables.buttons.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.3.3/js/buttons.html5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.3.3/js/buttons.bootstrap5.min.js"></script>
+
+<script src="<?= url('/assets/js/datatable.common.js') ?>"></script>
+<script src="<?= url('/assets/js/datatable.files.js') ?>"></script>


### PR DESCRIPTION
## Summary
- add FilesController for listing and uploading files through FileService
- register /dashboard/files routes and add templates
- provide DataTables script for files listing

## Testing
- `composer tests` *(fails: phpunit not found)*
- `composer install` *(fails: ext-redis missing)*
- `composer install --ignore-platform-req=ext-redis` *(fails: GitHub 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ade640822c832d8b81739c2d62e577