### PR TITLE
Implement files datatable with view and download actions

### DIFF
--- a/public/assets/js/datatable.files.js
+++ b/public/assets/js/datatable.files.js
@@ -1,16 +1,20 @@
 $(document).ready(function() {
   createDatatable('#filesTable', '/dashboard/files/data', [
     { data: 'id' },
-    { data: 'type' },
     { data: 'original_name' },
-    { data: 'mime_type' },
-    { data: 'size' },
+    { data: 'type' },
+    { data: 'file_id' },
     { data: 'created_at' },
     {
       data: null,
       className: 'text-end',
       render: function(data, type, row) {
-        return '<a href="/dashboard/files/' + row.id + '" class="btn btn-sm btn-outline-secondary">View</a>';
+        return '<a href="/dashboard/files/' + row.id + '" class="btn btn-sm btn-outline-secondary me-1">'
+          + '<i class="bi bi-eye" title="Просмотр"></i>'
+          + '</a>'
+          + '<a href="/dashboard/files/' + row.id + '/download" class="btn btn-sm btn-outline-secondary">'
+          + '<i class="bi bi-download" title="Скачать"></i>'
+          + '</a>';
       },
       orderable: false,
       searchable: false

--- a/templates/dashboard/files/index.php
+++ b/templates/dashboard/files/index.php
@@ -10,10 +10,9 @@
     <thead>
     <tr>
         <th>ID</th>
-        <th>Type</th>
         <th>Name</th>
-        <th>MIME</th>
-        <th>Size</th>
+        <th>Type</th>
+        <th>File ID</th>
         <th>Created</th>
         <th class="text-end">Actions</th>
     </tr>
@@ -22,10 +21,9 @@
     <tfoot>
     <tr>
         <th>ID</th>
-        <th>Type</th>
         <th>Name</th>
-        <th>MIME</th>
-        <th>Size</th>
+        <th>Type</th>
+        <th>File ID</th>
         <th>Created</th>
         <th class="text-end">Actions</th>
     </tr>


### PR DESCRIPTION
## Summary
- display id, name, type, file identifier and created date in files datatable
- add view and download actions
- load files datatable script on files dashboard page

## Testing
- `composer tests` *(fails: phpunit not found)*
- `composer install --ignore-platform-req=ext-redis` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68ade7985540832dacc1d83e6cbb5617